### PR TITLE
build: use shared browserslist config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         npm-test:
         - i18n_extract
-        - is-es5
         - lint
         - test
         node: [12, 14, 16]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         npm-test:
         - i18n_extract
+        - is-es6
         - lint
         - test
         node: [12, 14, 16]

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transi
 # This directory must match .babelrc .
 transifex_temp = ./temp/babel-plugin-react-intl
 
-NPM_TESTS=build i18n_extract lint test is-es5
+NPM_TESTS=build i18n_extract lint test
 
 .PHONY: test
 test: $(addprefix test.npm.,$(NPM_TESTS))  ## validate ci suite

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transi
 # This directory must match .babelrc .
 transifex_temp = ./temp/babel-plugin-react-intl
 
-NPM_TESTS=build i18n_extract lint test
+NPM_TESTS=build i18n_extract lint test is-es6
 
 .PHONY: test
 test: $(addprefix test.npm.,$(NPM_TESTS))  ## validate ci suite

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
       "devDependencies": {
         "@commitlint/cli": "13.2.1",
         "@commitlint/config-angular": "13.2.0",
+        "@edx/browserslist-config": "1.0.0",
         "@edx/frontend-build": "9.2.2",
         "@edx/reactifex": "1.1.0",
         "codecov": "3.8.3",
@@ -2211,6 +2212,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
       "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
+    },
+    "node_modules/@edx/browserslist-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.0.0.tgz",
+      "integrity": "sha512-gLAlpz9Y5VruxqiUBTROG7PvouIxoMc6dvhvNpXUDHRN0KEke+zBj+zJ4frL9kGbkeex273nzSazbG42hNDLrg==",
+      "dev": true
     },
     "node_modules/@edx/eslint-config": {
       "version": "2.0.0",
@@ -12178,9 +12185,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
-      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
       "dev": true
     },
     "node_modules/import-fresh": {
@@ -24750,6 +24757,12 @@
       "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
       "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
     },
+    "@edx/browserslist-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.0.0.tgz",
+      "integrity": "sha512-gLAlpz9Y5VruxqiUBTROG7PvouIxoMc6dvhvNpXUDHRN0KEke+zBj+zJ4frL9kGbkeex273nzSazbG42hNDLrg==",
+      "dev": true
+    },
     "@edx/eslint-config": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-2.0.0.tgz",
@@ -32587,9 +32600,9 @@
       "dev": true
     },
     "immutable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
-      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
       "dev": true
     },
     "import-fresh": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "build": "fedx-scripts webpack",
     "i18n_extract": "BABEL_ENV=i18n fedx-scripts babel src --quiet > /dev/null",
-    "is-es5": "es-check es5 ./dist/*.js",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
@@ -25,8 +24,7 @@
     "access": "public"
   },
   "browserslist": [
-    "last 2 versions",
-    "ie 11"
+    "extends @edx/browserslist-config"
   ],
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
@@ -63,6 +61,7 @@
   "devDependencies": {
     "@commitlint/cli": "13.2.1",
     "@commitlint/config-angular": "13.2.0",
+    "@edx/browserslist-config": "1.0.0",
     "@edx/frontend-build": "9.2.2",
     "@edx/reactifex": "1.1.0",
     "codecov": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "fedx-scripts webpack",
     "i18n_extract": "BABEL_ENV=i18n fedx-scripts babel src --quiet > /dev/null",
+    "is-es6": "es-check es6 ./dist/*.js",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",


### PR DESCRIPTION
* Removes custom `browserslist` configuration in favor of using a [shared configuration](https://github.com/edx/browserslist-config).
* Removes `is-es5` check in CI since ES5 was only needed for IE 11 support which is dropped. The supported browsers defined by the shared configuration all [natively support ES6](https://caniuse.com/?search=es6).

This change reduces the resultant asset bundle size.