### PR TITLE
build: Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @edx/community-engineering


### PR DESCRIPTION
The community-engineering team no longer exists, we don't want this file.