### PR TITLE
fix: show site name instead edX

### DIFF
--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -1,6 +1,6 @@
 {
   "profile.age.headline": "لا يمكن مشاركة ملفك الشخصي",
-  "profile.age.details": "لمشاركة ملفك الشخصي مع متعلمي edX الآخرين يجب التحقق من أن يكون عمرك أكثر من ١٣ سنة",
+  "profile.age.details": "لمشاركة ملفك الشخصي مع متعلمي {siteName} الآخرين يجب التحقق من أن يكون عمرك أكثر من ١٣ سنة",
   "profile.age.set.date": "اضبط تاريخ ميلاك",
   "profile.datejoined.member.since": "عضو منذُ {year}",
   "profile.bio.empty": "أضف نبذة قصيرة",
@@ -33,7 +33,7 @@
   "profile.formcontrols.button.saving": "جاري الحفظ",
   "profile.formcontrols.button.saved": "تم الحفظ",
   "profile.visibility.who.just.me": "أنا فقط",
-  "profile.visibility.who.everyone": "جميع أعضاء edX",
+  "profile.visibility.who.everyone": "جميع أعضاء {siteName}",
   "profile.name.full.name": "الاسم الكامل",
   "profile.name.details": "هذا هو الاسم الذي سيظهر في حسابك وفي شهاداتك",
   "profile.name.empty": "إضافة اسم",
@@ -48,5 +48,5 @@
   "profile.notfound.message": "الصفحة التي تبحث عنها غير متوفرة أو هناك خطأ في نص الرابط. الرجاء التحقق من الرابط والمحاولة مجددا.",
   "profile.viewMyRecords": "عرض سجلّاتي",
   "profile.loading": "جاري تحميل الملف الشخصي ...",
-  "profile.username.description": "Your profile information is only visible to you. Only your username is visible to others on edX."
+  "profile.username.description": "Your profile information is only visible to you. Only your username is visible to others on {siteName}."
 }

--- a/src/i18n/messages/es_419.json
+++ b/src/i18n/messages/es_419.json
@@ -1,6 +1,6 @@
 {
   "profile.age.headline": "Tu perfil no puede ser compartido.",
-  "profile.age.details": "Para compartir tu perfil con otros estudiantes de edX, debes confirmar que tienes más de 13 años.",
+  "profile.age.details": "Para compartir tu perfil con otros estudiantes de {siteName}, debes confirmar que tienes más de 13 años.",
   "profile.age.set.date": "Establece tu fecha de nacimiento",
   "profile.datejoined.member.since": "Miembro desde {year}",
   "profile.bio.empty": "Añade una breve biografía",
@@ -33,7 +33,7 @@
   "profile.formcontrols.button.saving": "Guardando",
   "profile.formcontrols.button.saved": "Guardado",
   "profile.visibility.who.just.me": "Solo yo",
-  "profile.visibility.who.everyone": "Todos en edX",
+  "profile.visibility.who.everyone": "Todos en {siteName}",
   "profile.name.full.name": "Nombre completo",
   "profile.name.details": "Este es el nombre que aparecerá en tu cuenta y en tus certificados.",
   "profile.name.empty": "Añade nombre",
@@ -48,5 +48,5 @@
   "profile.notfound.message": "La página que estas buscando no está disponible o hay un error en la URL. Por favor, comprueba la URL y vuelve a intentarlo.",
   "profile.viewMyRecords": "Ver mis registros",
   "profile.loading": "Cargando perfil...",
-  "profile.username.description": "La información de tu perfil es solo visible para ti. Únicamente tu nombre de usuario es visible para otros en edX."
+  "profile.username.description": "La información de tu perfil es solo visible para ti. Únicamente tu nombre de usuario es visible para otros en {siteName}."
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1,6 +1,6 @@
 {
   "profile.age.headline": "Votre profil ne peut pas être partagé.",
-  "profile.age.details": "Pour partager votre profil avec d'autres apprenants edX, vous devez confirmer que vous avez plus de 13 ans.",
+  "profile.age.details": "Pour partager votre profil avec d'autres apprenants {siteName}, vous devez confirmer que vous avez plus de 13 ans.",
   "profile.age.set.date": "Définissez votre date de naissance",
   "profile.datejoined.member.since": "Membre depuis {year}",
   "profile.bio.empty": "Ajouter une courte biographie",
@@ -33,7 +33,7 @@
   "profile.formcontrols.button.saving": "Enregistrement",
   "profile.formcontrols.button.saved": "Enregistré",
   "profile.visibility.who.just.me": "Juste moi",
-  "profile.visibility.who.everyone": "Tout le monde sur edX",
+  "profile.visibility.who.everyone": "Tout le monde sur {siteName}",
   "profile.name.full.name": "Nom complet",
   "profile.name.details": "C'est le nom qui apparaît dans votre compte et sur vos certificats.",
   "profile.name.empty": "Ajouter un nom",
@@ -48,5 +48,5 @@
   "profile.notfound.message": "La page que vous recherchez n'est pas disponible ou il y a une erreur dans l'URL. Veuillez vérifier l'URL et réessayer.",
   "profile.viewMyRecords": "Voir mes succès",
   "profile.loading": "Chargement du profil....",
-  "profile.username.description": "Les informations de ton profil ne sont visibles que par toi. Seul votre nom d'utilisateur est visible par les autres utilisateurs d'edX."
+  "profile.username.description": "Les informations de ton profil ne sont visibles que par toi. Seul votre nom d'utilisateur est visible par les autres utilisateurs d'{siteName}."
 }

--- a/src/i18n/messages/zh_CN.json
+++ b/src/i18n/messages/zh_CN.json
@@ -1,6 +1,6 @@
 {
   "profile.age.headline": "Your profile cannot be shared.",
-  "profile.age.details": "To share your profile with other edX learners, you must confirm that you are over the age of 13.",
+  "profile.age.details": "To share your profile with other {siteName} learners, you must confirm that you are over the age of 13.",
   "profile.age.set.date": "Set your date of birth",
   "profile.datejoined.member.since": "Member since {year}",
   "profile.bio.empty": "Add a short bio",
@@ -33,7 +33,7 @@
   "profile.formcontrols.button.saving": "Saving",
   "profile.formcontrols.button.saved": "Saved",
   "profile.visibility.who.just.me": "Just me",
-  "profile.visibility.who.everyone": "Everyone on edX",
+  "profile.visibility.who.everyone": "Everyone on {siteName}",
   "profile.name.full.name": "Full Name",
   "profile.name.details": "This is the name that appears in your account and on your certificates.",
   "profile.name.empty": "Add name",
@@ -48,5 +48,5 @@
   "profile.notfound.message": "The page you're looking for is unavailable or there's an error in the URL. Please check the URL and try again.",
   "profile.viewMyRecords": "View My Records",
   "profile.loading": "Profile loading...",
-  "profile.username.description": "Your profile information is only visible to you. Only your username is visible to others on edX."
+  "profile.username.description": "Your profile information is only visible to you. Only your username is visible to others on {siteName}."
 }

--- a/src/profile/AgeMessage.jsx
+++ b/src/profile/AgeMessage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { StatusAlert } from '@edx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { getConfig } from '@edx/frontend-platform';
 
 function AgeMessage({ accountSettingsUrl }) {
   return (
@@ -17,9 +18,12 @@ function AgeMessage({ accountSettingsUrl }) {
           />
           <FormattedMessage
             id="profile.age.details"
-            defaultMessage="To share your profile with other edX learners, you must confirm that you are over the age of 13."
+            defaultMessage="To share your profile with other {siteName} learners, you must confirm that you are over the age of 13."
             description="Error message"
             tagName="p"
+            values={{
+              siteName: getConfig().SITE_NAME,
+            }}
           />
           <a href={accountSettingsUrl}>
             <FormattedMessage

--- a/src/profile/UsernameDescription.jsx
+++ b/src/profile/UsernameDescription.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { VisibilityOff } from '@edx/paragon/icons';
 import { Icon } from '@edx/paragon';
+import { getConfig } from '@edx/frontend-platform';
 
 function UsernameDescription() {
   return (
@@ -10,8 +11,11 @@ function UsernameDescription() {
       <div className="username-description">
         <FormattedMessage
           id="profile.username.description"
-          defaultMessage="Your profile information is only visible to you. Only your username is visible to others on edX."
+          defaultMessage="Your profile information is only visible to you. Only your username is visible to others on {siteName}."
           description="A description of the username field"
+          values={{
+            siteName: getConfig().SITE_NAME,
+          }}
         />
       </div>
     </div>

--- a/src/profile/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/profile/__snapshots__/ProfilePage.test.jsx.snap
@@ -130,7 +130,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing other profi
                 className="username-description"
               >
                 <span>
-                  Your profile information is only visible to you. Only your username is visible to others on edX.
+                  Your profile information is only visible to you. Only your username is visible to others on localhost.
                 </span>
               </div>
             </div>
@@ -197,7 +197,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing other profi
                 className="username-description"
               >
                 <span>
-                  Your profile information is only visible to you. Only your username is visible to others on edX.
+                  Your profile information is only visible to you. Only your username is visible to others on localhost.
                 </span>
               </div>
             </div>
@@ -678,7 +678,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
                     />
                   </svg>
                    
-                  Everyone on edX
+                  Everyone on localhost
                 </span>
               </p>
             </div>
@@ -768,7 +768,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
                     />
                   </svg>
                    
-                  Everyone on edX
+                  Everyone on localhost
                 </span>
               </p>
             </div>
@@ -948,7 +948,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
                     />
                   </svg>
                    
-                  Everyone on edX
+                  Everyone on localhost
                 </span>
               </p>
             </div>
@@ -1127,7 +1127,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
                     />
                   </svg>
                    
-                  Everyone on edX
+                  Everyone on localhost
                 </span>
               </p>
             </div>
@@ -1217,7 +1217,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
                     />
                   </svg>
                    
-                  Everyone on edX
+                  Everyone on localhost
                 </span>
               </p>
             </div>
@@ -1741,7 +1741,7 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
                     />
                   </svg>
                    
-                  Everyone on edX
+                  Everyone on localhost
                 </span>
               </p>
             </div>
@@ -1831,7 +1831,7 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
                     />
                   </svg>
                    
-                  Everyone on edX
+                  Everyone on localhost
                 </span>
               </p>
             </div>
@@ -2011,7 +2011,7 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
                     />
                   </svg>
                    
-                  Everyone on edX
+                  Everyone on localhost
                 </span>
               </p>
             </div>
@@ -2209,7 +2209,7 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
                         <option
                           value="all_users"
                         >
-                          Everyone on edX
+                          Everyone on localhost
                         </option>
                       </select>
                     </span>
@@ -2348,7 +2348,7 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
                     />
                   </svg>
                    
-                  Everyone on edX
+                  Everyone on localhost
                 </span>
               </p>
             </div>
@@ -2782,7 +2782,7 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
                     />
                   </svg>
                    
-                  Everyone on edX
+                  Everyone on localhost
                 </span>
               </p>
             </div>
@@ -2872,7 +2872,7 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
                     />
                   </svg>
                    
-                  Everyone on edX
+                  Everyone on localhost
                 </span>
               </p>
             </div>
@@ -3052,7 +3052,7 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
                     />
                   </svg>
                    
-                  Everyone on edX
+                  Everyone on localhost
                 </span>
               </p>
             </div>
@@ -3231,7 +3231,7 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
                     />
                   </svg>
                    
-                  Everyone on edX
+                  Everyone on localhost
                 </span>
               </p>
             </div>
@@ -3321,7 +3321,7 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
                     />
                   </svg>
                    
-                  Everyone on edX
+                  Everyone on localhost
                 </span>
               </p>
             </div>

--- a/src/profile/forms/elements/Visibility.jsx
+++ b/src/profile/forms/elements/Visibility.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { getConfig } from '@edx/frontend-platform';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEyeSlash, faEye } from '@fortawesome/free-regular-svg-icons';
 
@@ -10,7 +11,7 @@ function Visibility({ to, intl }) {
   const icon = to === 'private' ? faEyeSlash : faEye;
   const label = to === 'private'
     ? intl.formatMessage(messages['profile.visibility.who.just.me'])
-    : intl.formatMessage(messages['profile.visibility.who.everyone']);
+    : intl.formatMessage(messages['profile.visibility.who.everyone'], { siteName: getConfig().SITE_NAME });
 
   return (
     <span className="ml-auto small text-muted">
@@ -43,7 +44,7 @@ function VisibilitySelect({ intl, className, ...props }) {
           {intl.formatMessage(messages['profile.visibility.who.just.me'])}
         </option>
         <option key="all_users" value="all_users">
-          {intl.formatMessage(messages['profile.visibility.who.everyone'])}
+          {intl.formatMessage(messages['profile.visibility.who.everyone'], { siteName: getConfig().SITE_NAME })}
         </option>
       </select>
     </span>

--- a/src/profile/forms/elements/Visibility.messages.jsx
+++ b/src/profile/forms/elements/Visibility.messages.jsx
@@ -8,7 +8,7 @@ const messages = defineMessages({
   },
   'profile.visibility.who.everyone': {
     id: 'profile.visibility.who.everyone',
-    defaultMessage: 'Everyone on edX',
+    defaultMessage: 'Everyone on {siteName}',
     description: 'What users can see this area?',
   },
 });


### PR DESCRIPTION
Description

This PR backports (cherry picked from commit https://github.com/openedx/frontend-app-profile/commit/1acc1d026212155338bcd4ad4322336d5e323c1c) changing references from edX to the proper site name. Refer to https://github.com/openedx/build-test-release-wg/issues/156 for more information about the backport.