### PR TITLE
Paragon form component deprecations

### DIFF
--- a/src/profile/ProfilePage.test.jsx
+++ b/src/profile/ProfilePage.test.jsx
@@ -146,6 +146,93 @@ describe('<ProfilePage />', () => {
       expect(tree).toMatchSnapshot();
     });
 
+    it('while saving an edited bio with error', () => {
+      const storeData = JSON.parse(JSON.stringify(storeMocks.savingEditedBio));
+      storeData.profilePage.errors.bio = { userMessage: 'bio error' };
+      const component = (
+        <AppContext.Provider
+          value={{
+            authenticatedUser: { userId: 123, username: 'staff', administrator: true },
+            config: getConfig(),
+          }}
+        >
+          <IntlProvider locale="en">
+            <Provider store={mockStore(storeData)}>
+              <ProfilePage {...requiredProfilePageProps} />
+            </Provider>
+          </IntlProvider>
+        </AppContext.Provider>
+      );
+      const tree = renderer.create(component).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('test country edit with error', () => {
+      const storeData = JSON.parse(JSON.stringify(storeMocks.savingEditedBio));
+      storeData.profilePage.errors.country = { userMessage: 'country error' };
+      storeData.profilePage.currentlyEditingField = 'country';
+      const component = (
+        <AppContext.Provider
+          value={{
+            authenticatedUser: { userId: 123, username: 'staff', administrator: true },
+            config: getConfig(),
+          }}
+        >
+          <IntlProvider locale="en">
+            <Provider store={mockStore(storeData)}>
+              <ProfilePage {...requiredProfilePageProps} />
+            </Provider>
+          </IntlProvider>
+        </AppContext.Provider>
+      );
+      const tree = renderer.create(component).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('test education edit with error', () => {
+      const storeData = JSON.parse(JSON.stringify(storeMocks.savingEditedBio));
+      storeData.profilePage.errors.levelOfEducation = { userMessage: 'education error' };
+      storeData.profilePage.currentlyEditingField = 'levelOfEducation';
+      const component = (
+        <AppContext.Provider
+          value={{
+            authenticatedUser: { userId: 123, username: 'staff', administrator: true },
+            config: getConfig(),
+          }}
+        >
+          <IntlProvider locale="en">
+            <Provider store={mockStore(storeData)}>
+              <ProfilePage {...requiredProfilePageProps} />
+            </Provider>
+          </IntlProvider>
+        </AppContext.Provider>
+      );
+      const tree = renderer.create(component).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('test preferreded language edit with error', () => {
+      const storeData = JSON.parse(JSON.stringify(storeMocks.savingEditedBio));
+      storeData.profilePage.errors.languageProficiencies = { userMessage: 'preferred language error' };
+      storeData.profilePage.currentlyEditingField = 'languageProficiencies';
+      const component = (
+        <AppContext.Provider
+          value={{
+            authenticatedUser: { userId: 123, username: 'staff', administrator: true },
+            config: getConfig(),
+          }}
+        >
+          <IntlProvider locale="en">
+            <Provider store={mockStore(storeData)}>
+              <ProfilePage {...requiredProfilePageProps} />
+            </Provider>
+          </IntlProvider>
+        </AppContext.Provider>
+      );
+      const tree = renderer.create(component).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
     it('without credentials service', () => {
       const config = getConfig();
       config.CREDENTIALS_BASE_URL = '';

--- a/src/profile/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/profile/__snapshots__/ProfilePage.test.jsx.snap
@@ -2137,7 +2137,7 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
                 onSubmit={[Function]}
               >
                 <div
-                  className="form-group"
+                  className="pgn__form-group"
                 >
                   <label
                     className="edit-section-header"
@@ -2146,7 +2146,6 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
                     About Me
                   </label>
                   <textarea
-                    aria-describedby=""
                     className="form-control"
                     id="bio"
                     name="bio"

--- a/src/profile/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/profile/__snapshots__/ProfilePage.test.jsx.snap
@@ -31,6 +31,5654 @@ exports[`<ProfilePage /> Renders correctly in various states app loading 1`] = `
 </div>
 `;
 
+exports[`<ProfilePage /> Renders correctly in various states test country edit with error 1`] = `
+<div
+  className="profile-page"
+>
+  <div
+    className="profile-page-bg-banner bg-primary d-none d-md-block p-relative"
+  />
+  <div
+    className="container-fluid"
+  >
+    <div
+      className="row align-items-center pt-4 mb-4 pt-md-0 mb-md-0"
+    >
+      <div
+        className="col-auto col-md-4 col-lg-3"
+      >
+        <div
+          className="d-flex align-items-center d-md-block"
+        >
+          <div
+            className="profile-avatar-wrap position-relative"
+          >
+            <div
+              className="profile-avatar rounded-circle bg-light"
+            >
+              <div
+                className="profile-avatar-menu-container"
+              >
+                <div
+                  className="dropdown"
+                  data-testid="dropdown"
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="dropdown-toggle btn btn-primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Change
+                  </button>
+                </div>
+              </div>
+              <img
+                alt="profile avatar"
+                className="w-100 h-100 d-block rounded-circle overflow-hidden"
+                data-hj-suppress={true}
+                src="http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_500.jpg?v=1552495012"
+                style={
+                  Object {
+                    "objectFit": "cover",
+                  }
+                }
+              />
+            </div>
+            <form
+              encType="multipart/form-data"
+              onSubmit={[Function]}
+            >
+              <input
+                accept=".jpg, .jpeg, .png"
+                className="d-none form-control-file"
+                id="photo-file"
+                name="file"
+                onChange={[Function]}
+                type="file"
+              />
+            </form>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col pl-0"
+      >
+        <div
+          className="d-md-none"
+        >
+          <span
+            data-hj-suppress={true}
+          >
+            <h1
+              className="h2 mb-0 font-weight-bold"
+            >
+              staff
+            </h1>
+            <p
+              className="mb-0"
+            >
+              <span>
+                Member since 
+                <span>
+                  2017
+                </span>
+              </span>
+            </p>
+            <hr
+              className="d-none d-md-block"
+            />
+          </span>
+        </div>
+        <div
+          className="d-none d-md-block float-right"
+        >
+          <a
+            className="pgn__hyperlink default-link standalone-link btn btn-primary"
+            href="http://localhost:18150/records"
+            onClick={[Function]}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            View My Records
+            <span
+              className="pgn__hyperlink__external-icon"
+              title="Opens in a new tab"
+            >
+              <span
+                className="pgn__icon"
+                style={
+                  Object {
+                    "height": "1em",
+                    "width": "1em",
+                  }
+                }
+              >
+                <svg
+                  aria-hidden={true}
+                  fill="none"
+                  focusable={false}
+                  height={24}
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M19 19H5V5h7V3H3v18h18v-9h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span
+                  className="sr-only"
+                >
+                  in a new tab
+                </span>
+              </span>
+            </span>
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      className="row"
+    >
+      <div
+        className="col-md-4 col-lg-4"
+      >
+        <div
+          className="d-none d-md-block mb-4"
+        >
+          <span
+            data-hj-suppress={true}
+          >
+            <h1
+              className="h2 mb-0 font-weight-bold"
+            >
+              staff
+            </h1>
+            <p
+              className="mb-0"
+            >
+              <span>
+                Member since 
+                <span>
+                  2017
+                </span>
+              </span>
+            </p>
+            <hr
+              className="d-none d-md-block"
+            />
+          </span>
+        </div>
+        <div
+          className="d-md-none mb-4"
+        >
+          <a
+            className="pgn__hyperlink default-link standalone-link btn btn-primary"
+            href="http://localhost:18150/records"
+            onClick={[Function]}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            View My Records
+            <span
+              className="pgn__hyperlink__external-icon"
+              title="Opens in a new tab"
+            >
+              <span
+                className="pgn__icon"
+                style={
+                  Object {
+                    "height": "1em",
+                    "width": "1em",
+                  }
+                }
+              >
+                <svg
+                  aria-hidden={true}
+                  fill="none"
+                  focusable={false}
+                  height={24}
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M19 19H5V5h7V3H3v18h18v-9h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span
+                  className="sr-only"
+                >
+                  in a new tab
+                </span>
+              </span>
+            </span>
+          </a>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Full Name
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye-slash fa-w-20 "
+                    data-icon="eye-slash"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 640 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M634 471L36 3.51A16 16 0 0 0 13.51 6l-10 12.49A16 16 0 0 0 6 41l598 467.49a16 16 0 0 0 22.49-2.49l10-12.49A16 16 0 0 0 634 471zM296.79 146.47l134.79 105.38C429.36 191.91 380.48 144 320 144a112.26 112.26 0 0 0-23.21 2.47zm46.42 219.07L208.42 260.16C210.65 320.09 259.53 368 320 368a113 113 0 0 0 23.21-2.46zM320 112c98.65 0 189.09 55 237.93 144a285.53 285.53 0 0 1-44 60.2l37.74 29.5a333.7 333.7 0 0 0 52.9-75.11 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64c-36.7 0-71.71 7-104.63 18.81l46.41 36.29c18.94-4.3 38.34-7.1 58.22-7.1zm0 288c-98.65 0-189.08-55-237.93-144a285.47 285.47 0 0 1 44.05-60.19l-37.74-29.5a333.6 333.6 0 0 0-52.89 75.1 32.35 32.35 0 0 0 0 29.19C89.72 376.41 197.08 448 320 448c36.7 0 71.71-7.05 104.63-18.81l-46.41-36.28C359.28 397.2 339.89 400 320 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Just me
+                </span>
+              </p>
+            </div>
+            <p
+              className="h5"
+              data-hj-suppress={true}
+            >
+              Lemon Seltzer
+            </p>
+            <small
+              className="form-text text-muted"
+            >
+              This is the name that appears in your account and on your certificates.
+            </small>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              aria-labelledby="country-label"
+              role="dialog"
+            >
+              <form
+                onSubmit={[Function]}
+              >
+                <div
+                  className="pgn__form-group"
+                >
+                  <label
+                    className="edit-section-header"
+                    htmlFor="country"
+                  >
+                    Location
+                  </label>
+                  <select
+                    className="form-control"
+                    data-hj-suppress={true}
+                    id="country"
+                    name="country"
+                    onChange={[Function]}
+                    type="select"
+                    value="ME"
+                  >
+                    <option
+                      value=""
+                    >
+                       
+                    </option>
+                    <option
+                      value="AF"
+                    >
+                      Afghanistan
+                    </option>
+                    <option
+                      value="AL"
+                    >
+                      Albania
+                    </option>
+                    <option
+                      value="DZ"
+                    >
+                      Algeria
+                    </option>
+                    <option
+                      value="AS"
+                    >
+                      American Samoa
+                    </option>
+                    <option
+                      value="AD"
+                    >
+                      Andorra
+                    </option>
+                    <option
+                      value="AO"
+                    >
+                      Angola
+                    </option>
+                    <option
+                      value="AI"
+                    >
+                      Anguilla
+                    </option>
+                    <option
+                      value="AQ"
+                    >
+                      Antarctica
+                    </option>
+                    <option
+                      value="AG"
+                    >
+                      Antigua and Barbuda
+                    </option>
+                    <option
+                      value="AR"
+                    >
+                      Argentina
+                    </option>
+                    <option
+                      value="AM"
+                    >
+                      Armenia
+                    </option>
+                    <option
+                      value="AW"
+                    >
+                      Aruba
+                    </option>
+                    <option
+                      value="AU"
+                    >
+                      Australia
+                    </option>
+                    <option
+                      value="AT"
+                    >
+                      Austria
+                    </option>
+                    <option
+                      value="AZ"
+                    >
+                      Azerbaijan
+                    </option>
+                    <option
+                      value="BS"
+                    >
+                      Bahamas
+                    </option>
+                    <option
+                      value="BH"
+                    >
+                      Bahrain
+                    </option>
+                    <option
+                      value="BD"
+                    >
+                      Bangladesh
+                    </option>
+                    <option
+                      value="BB"
+                    >
+                      Barbados
+                    </option>
+                    <option
+                      value="BY"
+                    >
+                      Belarus
+                    </option>
+                    <option
+                      value="BE"
+                    >
+                      Belgium
+                    </option>
+                    <option
+                      value="BZ"
+                    >
+                      Belize
+                    </option>
+                    <option
+                      value="BJ"
+                    >
+                      Benin
+                    </option>
+                    <option
+                      value="BM"
+                    >
+                      Bermuda
+                    </option>
+                    <option
+                      value="BT"
+                    >
+                      Bhutan
+                    </option>
+                    <option
+                      value="BO"
+                    >
+                      Bolivia
+                    </option>
+                    <option
+                      value="BA"
+                    >
+                      Bosnia and Herzegovina
+                    </option>
+                    <option
+                      value="BW"
+                    >
+                      Botswana
+                    </option>
+                    <option
+                      value="BV"
+                    >
+                      Bouvet Island
+                    </option>
+                    <option
+                      value="BR"
+                    >
+                      Brazil
+                    </option>
+                    <option
+                      value="IO"
+                    >
+                      British Indian Ocean Territory
+                    </option>
+                    <option
+                      value="BN"
+                    >
+                      Brunei Darussalam
+                    </option>
+                    <option
+                      value="BG"
+                    >
+                      Bulgaria
+                    </option>
+                    <option
+                      value="BF"
+                    >
+                      Burkina Faso
+                    </option>
+                    <option
+                      value="BI"
+                    >
+                      Burundi
+                    </option>
+                    <option
+                      value="KH"
+                    >
+                      Cambodia
+                    </option>
+                    <option
+                      value="CM"
+                    >
+                      Cameroon
+                    </option>
+                    <option
+                      value="CA"
+                    >
+                      Canada
+                    </option>
+                    <option
+                      value="CV"
+                    >
+                      Cape Verde
+                    </option>
+                    <option
+                      value="KY"
+                    >
+                      Cayman Islands
+                    </option>
+                    <option
+                      value="CF"
+                    >
+                      Central African Republic
+                    </option>
+                    <option
+                      value="TD"
+                    >
+                      Chad
+                    </option>
+                    <option
+                      value="CL"
+                    >
+                      Chile
+                    </option>
+                    <option
+                      value="CN"
+                    >
+                      China
+                    </option>
+                    <option
+                      value="CX"
+                    >
+                      Christmas Island
+                    </option>
+                    <option
+                      value="CC"
+                    >
+                      Cocos (Keeling) Islands
+                    </option>
+                    <option
+                      value="CO"
+                    >
+                      Colombia
+                    </option>
+                    <option
+                      value="KM"
+                    >
+                      Comoros
+                    </option>
+                    <option
+                      value="CG"
+                    >
+                      Congo
+                    </option>
+                    <option
+                      value="CD"
+                    >
+                      Congo, the Democratic Republic of the
+                    </option>
+                    <option
+                      value="CK"
+                    >
+                      Cook Islands
+                    </option>
+                    <option
+                      value="CR"
+                    >
+                      Costa Rica
+                    </option>
+                    <option
+                      value="CI"
+                    >
+                      Cote D'Ivoire
+                    </option>
+                    <option
+                      value="HR"
+                    >
+                      Croatia
+                    </option>
+                    <option
+                      value="CU"
+                    >
+                      Cuba
+                    </option>
+                    <option
+                      value="CY"
+                    >
+                      Cyprus
+                    </option>
+                    <option
+                      value="CZ"
+                    >
+                      Czech Republic
+                    </option>
+                    <option
+                      value="DK"
+                    >
+                      Denmark
+                    </option>
+                    <option
+                      value="DJ"
+                    >
+                      Djibouti
+                    </option>
+                    <option
+                      value="DM"
+                    >
+                      Dominica
+                    </option>
+                    <option
+                      value="DO"
+                    >
+                      Dominican Republic
+                    </option>
+                    <option
+                      value="EC"
+                    >
+                      Ecuador
+                    </option>
+                    <option
+                      value="EG"
+                    >
+                      Egypt
+                    </option>
+                    <option
+                      value="SV"
+                    >
+                      El Salvador
+                    </option>
+                    <option
+                      value="GQ"
+                    >
+                      Equatorial Guinea
+                    </option>
+                    <option
+                      value="ER"
+                    >
+                      Eritrea
+                    </option>
+                    <option
+                      value="EE"
+                    >
+                      Estonia
+                    </option>
+                    <option
+                      value="ET"
+                    >
+                      Ethiopia
+                    </option>
+                    <option
+                      value="FK"
+                    >
+                      Falkland Islands (Malvinas)
+                    </option>
+                    <option
+                      value="FO"
+                    >
+                      Faroe Islands
+                    </option>
+                    <option
+                      value="FJ"
+                    >
+                      Fiji
+                    </option>
+                    <option
+                      value="FI"
+                    >
+                      Finland
+                    </option>
+                    <option
+                      value="FR"
+                    >
+                      France
+                    </option>
+                    <option
+                      value="GF"
+                    >
+                      French Guiana
+                    </option>
+                    <option
+                      value="PF"
+                    >
+                      French Polynesia
+                    </option>
+                    <option
+                      value="TF"
+                    >
+                      French Southern Territories
+                    </option>
+                    <option
+                      value="GA"
+                    >
+                      Gabon
+                    </option>
+                    <option
+                      value="GM"
+                    >
+                      Gambia
+                    </option>
+                    <option
+                      value="GE"
+                    >
+                      Georgia
+                    </option>
+                    <option
+                      value="DE"
+                    >
+                      Germany
+                    </option>
+                    <option
+                      value="GH"
+                    >
+                      Ghana
+                    </option>
+                    <option
+                      value="GI"
+                    >
+                      Gibraltar
+                    </option>
+                    <option
+                      value="GR"
+                    >
+                      Greece
+                    </option>
+                    <option
+                      value="GL"
+                    >
+                      Greenland
+                    </option>
+                    <option
+                      value="GD"
+                    >
+                      Grenada
+                    </option>
+                    <option
+                      value="GP"
+                    >
+                      Guadeloupe
+                    </option>
+                    <option
+                      value="GU"
+                    >
+                      Guam
+                    </option>
+                    <option
+                      value="GT"
+                    >
+                      Guatemala
+                    </option>
+                    <option
+                      value="GN"
+                    >
+                      Guinea
+                    </option>
+                    <option
+                      value="GW"
+                    >
+                      Guinea-Bissau
+                    </option>
+                    <option
+                      value="GY"
+                    >
+                      Guyana
+                    </option>
+                    <option
+                      value="HT"
+                    >
+                      Haiti
+                    </option>
+                    <option
+                      value="HM"
+                    >
+                      Heard Island and Mcdonald Islands
+                    </option>
+                    <option
+                      value="VA"
+                    >
+                      Holy See (Vatican City State)
+                    </option>
+                    <option
+                      value="HN"
+                    >
+                      Honduras
+                    </option>
+                    <option
+                      value="HK"
+                    >
+                      Hong Kong
+                    </option>
+                    <option
+                      value="HU"
+                    >
+                      Hungary
+                    </option>
+                    <option
+                      value="IS"
+                    >
+                      Iceland
+                    </option>
+                    <option
+                      value="IN"
+                    >
+                      India
+                    </option>
+                    <option
+                      value="ID"
+                    >
+                      Indonesia
+                    </option>
+                    <option
+                      value="IR"
+                    >
+                      Iran, Islamic Republic of
+                    </option>
+                    <option
+                      value="IQ"
+                    >
+                      Iraq
+                    </option>
+                    <option
+                      value="IE"
+                    >
+                      Ireland
+                    </option>
+                    <option
+                      value="IL"
+                    >
+                      Israel
+                    </option>
+                    <option
+                      value="IT"
+                    >
+                      Italy
+                    </option>
+                    <option
+                      value="JM"
+                    >
+                      Jamaica
+                    </option>
+                    <option
+                      value="JP"
+                    >
+                      Japan
+                    </option>
+                    <option
+                      value="JO"
+                    >
+                      Jordan
+                    </option>
+                    <option
+                      value="KZ"
+                    >
+                      Kazakhstan
+                    </option>
+                    <option
+                      value="KE"
+                    >
+                      Kenya
+                    </option>
+                    <option
+                      value="KI"
+                    >
+                      Kiribati
+                    </option>
+                    <option
+                      value="KP"
+                    >
+                      North Korea
+                    </option>
+                    <option
+                      value="KR"
+                    >
+                      South Korea
+                    </option>
+                    <option
+                      value="KW"
+                    >
+                      Kuwait
+                    </option>
+                    <option
+                      value="KG"
+                    >
+                      Kyrgyzstan
+                    </option>
+                    <option
+                      value="LA"
+                    >
+                      Lao People's Democratic Republic
+                    </option>
+                    <option
+                      value="LV"
+                    >
+                      Latvia
+                    </option>
+                    <option
+                      value="LB"
+                    >
+                      Lebanon
+                    </option>
+                    <option
+                      value="LS"
+                    >
+                      Lesotho
+                    </option>
+                    <option
+                      value="LR"
+                    >
+                      Liberia
+                    </option>
+                    <option
+                      value="LY"
+                    >
+                      Libya
+                    </option>
+                    <option
+                      value="LI"
+                    >
+                      Liechtenstein
+                    </option>
+                    <option
+                      value="LT"
+                    >
+                      Lithuania
+                    </option>
+                    <option
+                      value="LU"
+                    >
+                      Luxembourg
+                    </option>
+                    <option
+                      value="MO"
+                    >
+                      Macao
+                    </option>
+                    <option
+                      value="MG"
+                    >
+                      Madagascar
+                    </option>
+                    <option
+                      value="MW"
+                    >
+                      Malawi
+                    </option>
+                    <option
+                      value="MY"
+                    >
+                      Malaysia
+                    </option>
+                    <option
+                      value="MV"
+                    >
+                      Maldives
+                    </option>
+                    <option
+                      value="ML"
+                    >
+                      Mali
+                    </option>
+                    <option
+                      value="MT"
+                    >
+                      Malta
+                    </option>
+                    <option
+                      value="MH"
+                    >
+                      Marshall Islands
+                    </option>
+                    <option
+                      value="MQ"
+                    >
+                      Martinique
+                    </option>
+                    <option
+                      value="MR"
+                    >
+                      Mauritania
+                    </option>
+                    <option
+                      value="MU"
+                    >
+                      Mauritius
+                    </option>
+                    <option
+                      value="YT"
+                    >
+                      Mayotte
+                    </option>
+                    <option
+                      value="MX"
+                    >
+                      Mexico
+                    </option>
+                    <option
+                      value="FM"
+                    >
+                      Micronesia, Federated States of
+                    </option>
+                    <option
+                      value="MD"
+                    >
+                      Moldova, Republic of
+                    </option>
+                    <option
+                      value="MC"
+                    >
+                      Monaco
+                    </option>
+                    <option
+                      value="MN"
+                    >
+                      Mongolia
+                    </option>
+                    <option
+                      value="MS"
+                    >
+                      Montserrat
+                    </option>
+                    <option
+                      value="MA"
+                    >
+                      Morocco
+                    </option>
+                    <option
+                      value="MZ"
+                    >
+                      Mozambique
+                    </option>
+                    <option
+                      value="MM"
+                    >
+                      Myanmar
+                    </option>
+                    <option
+                      value="NA"
+                    >
+                      Namibia
+                    </option>
+                    <option
+                      value="NR"
+                    >
+                      Nauru
+                    </option>
+                    <option
+                      value="NP"
+                    >
+                      Nepal
+                    </option>
+                    <option
+                      value="NL"
+                    >
+                      Netherlands
+                    </option>
+                    <option
+                      value="NC"
+                    >
+                      New Caledonia
+                    </option>
+                    <option
+                      value="NZ"
+                    >
+                      New Zealand
+                    </option>
+                    <option
+                      value="NI"
+                    >
+                      Nicaragua
+                    </option>
+                    <option
+                      value="NE"
+                    >
+                      Niger
+                    </option>
+                    <option
+                      value="NG"
+                    >
+                      Nigeria
+                    </option>
+                    <option
+                      value="NU"
+                    >
+                      Niue
+                    </option>
+                    <option
+                      value="NF"
+                    >
+                      Norfolk Island
+                    </option>
+                    <option
+                      value="MK"
+                    >
+                      North Macedonia, Republic of
+                    </option>
+                    <option
+                      value="MP"
+                    >
+                      Northern Mariana Islands
+                    </option>
+                    <option
+                      value="NO"
+                    >
+                      Norway
+                    </option>
+                    <option
+                      value="OM"
+                    >
+                      Oman
+                    </option>
+                    <option
+                      value="PK"
+                    >
+                      Pakistan
+                    </option>
+                    <option
+                      value="PW"
+                    >
+                      Palau
+                    </option>
+                    <option
+                      value="PS"
+                    >
+                      Palestinian Territory, Occupied
+                    </option>
+                    <option
+                      value="PA"
+                    >
+                      Panama
+                    </option>
+                    <option
+                      value="PG"
+                    >
+                      Papua New Guinea
+                    </option>
+                    <option
+                      value="PY"
+                    >
+                      Paraguay
+                    </option>
+                    <option
+                      value="PE"
+                    >
+                      Peru
+                    </option>
+                    <option
+                      value="PH"
+                    >
+                      Philippines
+                    </option>
+                    <option
+                      value="PN"
+                    >
+                      Pitcairn
+                    </option>
+                    <option
+                      value="PL"
+                    >
+                      Poland
+                    </option>
+                    <option
+                      value="PT"
+                    >
+                      Portugal
+                    </option>
+                    <option
+                      value="PR"
+                    >
+                      Puerto Rico
+                    </option>
+                    <option
+                      value="QA"
+                    >
+                      Qatar
+                    </option>
+                    <option
+                      value="RE"
+                    >
+                      Reunion
+                    </option>
+                    <option
+                      value="RO"
+                    >
+                      Romania
+                    </option>
+                    <option
+                      value="RU"
+                    >
+                      Russian Federation
+                    </option>
+                    <option
+                      value="RW"
+                    >
+                      Rwanda
+                    </option>
+                    <option
+                      value="SH"
+                    >
+                      Saint Helena
+                    </option>
+                    <option
+                      value="KN"
+                    >
+                      Saint Kitts and Nevis
+                    </option>
+                    <option
+                      value="LC"
+                    >
+                      Saint Lucia
+                    </option>
+                    <option
+                      value="PM"
+                    >
+                      Saint Pierre and Miquelon
+                    </option>
+                    <option
+                      value="VC"
+                    >
+                      Saint Vincent and the Grenadines
+                    </option>
+                    <option
+                      value="WS"
+                    >
+                      Samoa
+                    </option>
+                    <option
+                      value="SM"
+                    >
+                      San Marino
+                    </option>
+                    <option
+                      value="ST"
+                    >
+                      Sao Tome and Principe
+                    </option>
+                    <option
+                      value="SA"
+                    >
+                      Saudi Arabia
+                    </option>
+                    <option
+                      value="SN"
+                    >
+                      Senegal
+                    </option>
+                    <option
+                      value="SC"
+                    >
+                      Seychelles
+                    </option>
+                    <option
+                      value="SL"
+                    >
+                      Sierra Leone
+                    </option>
+                    <option
+                      value="SG"
+                    >
+                      Singapore
+                    </option>
+                    <option
+                      value="SK"
+                    >
+                      Slovakia
+                    </option>
+                    <option
+                      value="SI"
+                    >
+                      Slovenia
+                    </option>
+                    <option
+                      value="SB"
+                    >
+                      Solomon Islands
+                    </option>
+                    <option
+                      value="SO"
+                    >
+                      Somalia
+                    </option>
+                    <option
+                      value="ZA"
+                    >
+                      South Africa
+                    </option>
+                    <option
+                      value="GS"
+                    >
+                      South Georgia and the South Sandwich Islands
+                    </option>
+                    <option
+                      value="ES"
+                    >
+                      Spain
+                    </option>
+                    <option
+                      value="LK"
+                    >
+                      Sri Lanka
+                    </option>
+                    <option
+                      value="SD"
+                    >
+                      Sudan
+                    </option>
+                    <option
+                      value="SR"
+                    >
+                      Suriname
+                    </option>
+                    <option
+                      value="SJ"
+                    >
+                      Svalbard and Jan Mayen
+                    </option>
+                    <option
+                      value="SZ"
+                    >
+                      Swaziland
+                    </option>
+                    <option
+                      value="SE"
+                    >
+                      Sweden
+                    </option>
+                    <option
+                      value="CH"
+                    >
+                      Switzerland
+                    </option>
+                    <option
+                      value="SY"
+                    >
+                      Syrian Arab Republic
+                    </option>
+                    <option
+                      value="TW"
+                    >
+                      Taiwan
+                    </option>
+                    <option
+                      value="TJ"
+                    >
+                      Tajikistan
+                    </option>
+                    <option
+                      value="TZ"
+                    >
+                      Tanzania, United Republic of
+                    </option>
+                    <option
+                      value="TH"
+                    >
+                      Thailand
+                    </option>
+                    <option
+                      value="TL"
+                    >
+                      Timor-Leste
+                    </option>
+                    <option
+                      value="TG"
+                    >
+                      Togo
+                    </option>
+                    <option
+                      value="TK"
+                    >
+                      Tokelau
+                    </option>
+                    <option
+                      value="TO"
+                    >
+                      Tonga
+                    </option>
+                    <option
+                      value="TT"
+                    >
+                      Trinidad and Tobago
+                    </option>
+                    <option
+                      value="TN"
+                    >
+                      Tunisia
+                    </option>
+                    <option
+                      value="TR"
+                    >
+                      Turkey
+                    </option>
+                    <option
+                      value="TM"
+                    >
+                      Turkmenistan
+                    </option>
+                    <option
+                      value="TC"
+                    >
+                      Turks and Caicos Islands
+                    </option>
+                    <option
+                      value="TV"
+                    >
+                      Tuvalu
+                    </option>
+                    <option
+                      value="UG"
+                    >
+                      Uganda
+                    </option>
+                    <option
+                      value="UA"
+                    >
+                      Ukraine
+                    </option>
+                    <option
+                      value="AE"
+                    >
+                      United Arab Emirates
+                    </option>
+                    <option
+                      value="GB"
+                    >
+                      United Kingdom
+                    </option>
+                    <option
+                      value="US"
+                    >
+                      United States of America
+                    </option>
+                    <option
+                      value="UM"
+                    >
+                      United States Minor Outlying Islands
+                    </option>
+                    <option
+                      value="UY"
+                    >
+                      Uruguay
+                    </option>
+                    <option
+                      value="UZ"
+                    >
+                      Uzbekistan
+                    </option>
+                    <option
+                      value="VU"
+                    >
+                      Vanuatu
+                    </option>
+                    <option
+                      value="VE"
+                    >
+                      Venezuela
+                    </option>
+                    <option
+                      value="VN"
+                    >
+                      Viet Nam
+                    </option>
+                    <option
+                      value="VG"
+                    >
+                      Virgin Islands, British
+                    </option>
+                    <option
+                      value="VI"
+                    >
+                      Virgin Islands, U.S.
+                    </option>
+                    <option
+                      value="WF"
+                    >
+                      Wallis and Futuna
+                    </option>
+                    <option
+                      value="EH"
+                    >
+                      Western Sahara
+                    </option>
+                    <option
+                      value="YE"
+                    >
+                      Yemen
+                    </option>
+                    <option
+                      value="ZM"
+                    >
+                      Zambia
+                    </option>
+                    <option
+                      value="ZW"
+                    >
+                      Zimbabwe
+                    </option>
+                    <option
+                      value="AX"
+                    >
+                      Åland Islands
+                    </option>
+                    <option
+                      value="BQ"
+                    >
+                      Bonaire, Sint Eustatius and Saba
+                    </option>
+                    <option
+                      value="CW"
+                    >
+                      Curaçao
+                    </option>
+                    <option
+                      value="GG"
+                    >
+                      Guernsey
+                    </option>
+                    <option
+                      value="IM"
+                    >
+                      Isle of Man
+                    </option>
+                    <option
+                      value="JE"
+                    >
+                      Jersey
+                    </option>
+                    <option
+                      value="ME"
+                    >
+                      Montenegro
+                    </option>
+                    <option
+                      value="BL"
+                    >
+                      Saint Barthélemy
+                    </option>
+                    <option
+                      value="MF"
+                    >
+                      Saint Martin (French part)
+                    </option>
+                    <option
+                      value="RS"
+                    >
+                      Serbia
+                    </option>
+                    <option
+                      value="SX"
+                    >
+                      Sint Maarten (Dutch part)
+                    </option>
+                    <option
+                      value="SS"
+                    >
+                      South Sudan
+                    </option>
+                    <option
+                      value="XK"
+                    >
+                      Kosovo
+                    </option>
+                  </select>
+                  <div
+                    className="pgn__form-control-description pgn__form-text pgn__form-text-invalid"
+                    id="country-2"
+                  >
+                    country error
+                  </div>
+                </div>
+                <div
+                  className="d-flex flex-row-reverse flex-wrap justify-content-end align-items-center"
+                >
+                  <div
+                    className="form-group d-flex flex-wrap"
+                  >
+                    <label
+                      className="col-form-label"
+                      htmlFor="visibilityCountry"
+                    >
+                      Who can see this:
+                    </label>
+                    <span
+                      className="d-flex align-items-center"
+                    >
+                      <span
+                        className="d-inline-block ml-1 mr-2"
+                        style={
+                          Object {
+                            "width": "1.5rem",
+                          }
+                        }
+                      >
+                        <svg
+                          aria-hidden="true"
+                          className="svg-inline--fa fa-eye fa-w-18 "
+                          data-icon="eye"
+                          data-prefix="far"
+                          focusable="false"
+                          role="img"
+                          style={Object {}}
+                          viewBox="0 0 576 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                            fill="currentColor"
+                            style={Object {}}
+                          />
+                        </svg>
+                      </span>
+                      <select
+                        className="d-inline-block w-auto form-control"
+                        id="visibilityCountry"
+                        name="visibilityCountry"
+                        onChange={[Function]}
+                        type="select"
+                        value="all_users"
+                      >
+                        <option
+                          value="private"
+                        >
+                          Just me
+                        </option>
+                        <option
+                          value="all_users"
+                        >
+                          Everyone on localhost
+                        </option>
+                      </select>
+                    </span>
+                  </div>
+                  <div
+                    className="form-group flex-shrink-0 flex-grow-1"
+                  >
+                    <button
+                      aria-disabled={false}
+                      aria-live="assertive"
+                      className="pgn__stateful-btn pgn__stateful-btn-state-pending btn btn-primary"
+                      disabled={false}
+                      onClick={[Function]}
+                      type="submit"
+                    >
+                      <span
+                        className="d-flex align-items-center justify-content-center"
+                      >
+                        <span
+                          className="pgn__stateful-btn-icon"
+                        >
+                          <span
+                            className="pgn__icon icon-spin"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="none"
+                              focusable={false}
+                              height={24}
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width={24}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M22 12A10 10 0 116.122 3.91l1.176 1.618A8 8 0 1020 12h2z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                        <span>
+                          Saving
+                        </span>
+                      </span>
+                    </button>
+                    <button
+                      className="btn btn-link"
+                      disabled={false}
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Primary Language Spoken
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <p
+              className="h5"
+              data-hj-suppress={true}
+            >
+              Yoruba
+            </p>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Education
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye-slash fa-w-20 "
+                    data-icon="eye-slash"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 640 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M634 471L36 3.51A16 16 0 0 0 13.51 6l-10 12.49A16 16 0 0 0 6 41l598 467.49a16 16 0 0 0 22.49-2.49l10-12.49A16 16 0 0 0 634 471zM296.79 146.47l134.79 105.38C429.36 191.91 380.48 144 320 144a112.26 112.26 0 0 0-23.21 2.47zm46.42 219.07L208.42 260.16C210.65 320.09 259.53 368 320 368a113 113 0 0 0 23.21-2.46zM320 112c98.65 0 189.09 55 237.93 144a285.53 285.53 0 0 1-44 60.2l37.74 29.5a333.7 333.7 0 0 0 52.9-75.11 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64c-36.7 0-71.71 7-104.63 18.81l46.41 36.29c18.94-4.3 38.34-7.1 58.22-7.1zm0 288c-98.65 0-189.08-55-237.93-144a285.47 285.47 0 0 1 44.05-60.19l-37.74-29.5a333.6 333.6 0 0 0-52.89 75.1 32.35 32.35 0 0 0 0 29.19C89.72 376.41 197.08 448 320 448c36.7 0 71.71-7.05 104.63-18.81l-46.41-36.28C359.28 397.2 339.89 400 320 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Just me
+                </span>
+              </p>
+            </div>
+            <p
+              className="h5"
+              data-hj-suppress={true}
+            >
+              Elementary/primary school
+            </p>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Social Links
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <ul
+              className="list-unstyled"
+            >
+              <li
+                className="form-group"
+              >
+                <a
+                  className="font-weight-bold"
+                  href="https://www.twitter.com/ALOHA"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-twitter fa-w-16 mr-2"
+                    data-icon="twitter"
+                    data-prefix="fab"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Twitter
+                </a>
+              </li>
+              <li
+                className="form-group"
+              >
+                <a
+                  className="font-weight-bold"
+                  href="https://www.facebook.com/aloha"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-facebook fa-w-16 mr-2"
+                    data-icon="facebook"
+                    data-prefix="fab"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256C504 119 393 8 256 8S8 119 8 256c0 123.78 90.69 226.38 209.25 245V327.69h-63V256h63v-54.64c0-62.15 37-96.48 93.67-96.48 27.14 0 55.52 4.84 55.52 4.84v61h-31.28c-30.8 0-40.41 19.12-40.41 38.73V256h68.78l-11 71.69h-57.78V501C413.31 482.38 504 379.78 504 256z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Facebook
+                </a>
+              </li>
+              <li
+                className="form-group"
+              >
+                <div>
+                  <button
+                    className="pl-0 text-left btn btn-link"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="svg-inline--fa fa-plus fa-w-14 fa-xs mr-2"
+                      data-icon="plus"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      style={Object {}}
+                      viewBox="0 0 448 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                        fill="currentColor"
+                        style={Object {}}
+                      />
+                    </svg>
+                    Add 
+                    LinkedIn
+                  </button>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pt-md-3 col-md-8 col-lg-7 offset-lg-1"
+      >
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                About Me
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <p
+              className="lead"
+              data-hj-suppress={true}
+            >
+              This is my bio
+            </p>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-4"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                My Certificates
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <div
+              className="row align-items-stretch"
+            >
+              <div
+                className="col col-sm-6 d-flex align-items-stretch"
+              >
+                <div
+                  className="card mb-4 certificate flex-grow-1"
+                >
+                  <div
+                    className="certificate-type-illustration"
+                    style={
+                      Object {
+                        "backgroundImage": "url(icon/mock/path)",
+                      }
+                    }
+                  />
+                  <div
+                    className="card-body d-flex flex-column"
+                  >
+                    <div
+                      className="card-title"
+                    >
+                      <p
+                        className="small mb-0"
+                      >
+                        Verified Certificate
+                      </p>
+                      <h4
+                        className="certificate-title"
+                      >
+                        edX Demonstration Course
+                      </h4>
+                    </div>
+                    <p
+                      className="small mb-0"
+                    >
+                      <span>
+                        From
+                      </span>
+                    </p>
+                    <p
+                      className="h6 mb-4"
+                    >
+                      edX
+                    </p>
+                    <div
+                      className="flex-grow-1"
+                    />
+                    <p
+                      className="small mb-2"
+                    >
+                      <span>
+                        Completed on 
+                        <span>
+                          3/4/2019
+                        </span>
+                      </span>
+                    </p>
+                    <div>
+                      <a
+                        className="pgn__hyperlink default-link standalone-link btn btn-outline-primary"
+                        href="http://www.example.com/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        View Certificate
+                        <span
+                          className="pgn__hyperlink__external-icon"
+                          title="Opens in a new tab"
+                        >
+                          <span
+                            className="pgn__icon"
+                            style={
+                              Object {
+                                "height": "1em",
+                                "width": "1em",
+                              }
+                            }
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="none"
+                              focusable={false}
+                              height={24}
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width={24}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M19 19H5V5h7V3H3v18h18v-9h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                            <span
+                              className="sr-only"
+                            >
+                              in a new tab
+                            </span>
+                          </span>
+                        </span>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<ProfilePage /> Renders correctly in various states test education edit with error 1`] = `
+<div
+  className="profile-page"
+>
+  <div
+    className="profile-page-bg-banner bg-primary d-none d-md-block p-relative"
+  />
+  <div
+    className="container-fluid"
+  >
+    <div
+      className="row align-items-center pt-4 mb-4 pt-md-0 mb-md-0"
+    >
+      <div
+        className="col-auto col-md-4 col-lg-3"
+      >
+        <div
+          className="d-flex align-items-center d-md-block"
+        >
+          <div
+            className="profile-avatar-wrap position-relative"
+          >
+            <div
+              className="profile-avatar rounded-circle bg-light"
+            >
+              <div
+                className="profile-avatar-menu-container"
+              >
+                <div
+                  className="dropdown"
+                  data-testid="dropdown"
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="dropdown-toggle btn btn-primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Change
+                  </button>
+                </div>
+              </div>
+              <img
+                alt="profile avatar"
+                className="w-100 h-100 d-block rounded-circle overflow-hidden"
+                data-hj-suppress={true}
+                src="http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_500.jpg?v=1552495012"
+                style={
+                  Object {
+                    "objectFit": "cover",
+                  }
+                }
+              />
+            </div>
+            <form
+              encType="multipart/form-data"
+              onSubmit={[Function]}
+            >
+              <input
+                accept=".jpg, .jpeg, .png"
+                className="d-none form-control-file"
+                id="photo-file"
+                name="file"
+                onChange={[Function]}
+                type="file"
+              />
+            </form>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col pl-0"
+      >
+        <div
+          className="d-md-none"
+        >
+          <span
+            data-hj-suppress={true}
+          >
+            <h1
+              className="h2 mb-0 font-weight-bold"
+            >
+              staff
+            </h1>
+            <p
+              className="mb-0"
+            >
+              <span>
+                Member since 
+                <span>
+                  2017
+                </span>
+              </span>
+            </p>
+            <hr
+              className="d-none d-md-block"
+            />
+          </span>
+        </div>
+        <div
+          className="d-none d-md-block float-right"
+        >
+          <a
+            className="pgn__hyperlink default-link standalone-link btn btn-primary"
+            href="http://localhost:18150/records"
+            onClick={[Function]}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            View My Records
+            <span
+              className="pgn__hyperlink__external-icon"
+              title="Opens in a new tab"
+            >
+              <span
+                className="pgn__icon"
+                style={
+                  Object {
+                    "height": "1em",
+                    "width": "1em",
+                  }
+                }
+              >
+                <svg
+                  aria-hidden={true}
+                  fill="none"
+                  focusable={false}
+                  height={24}
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M19 19H5V5h7V3H3v18h18v-9h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span
+                  className="sr-only"
+                >
+                  in a new tab
+                </span>
+              </span>
+            </span>
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      className="row"
+    >
+      <div
+        className="col-md-4 col-lg-4"
+      >
+        <div
+          className="d-none d-md-block mb-4"
+        >
+          <span
+            data-hj-suppress={true}
+          >
+            <h1
+              className="h2 mb-0 font-weight-bold"
+            >
+              staff
+            </h1>
+            <p
+              className="mb-0"
+            >
+              <span>
+                Member since 
+                <span>
+                  2017
+                </span>
+              </span>
+            </p>
+            <hr
+              className="d-none d-md-block"
+            />
+          </span>
+        </div>
+        <div
+          className="d-md-none mb-4"
+        >
+          <a
+            className="pgn__hyperlink default-link standalone-link btn btn-primary"
+            href="http://localhost:18150/records"
+            onClick={[Function]}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            View My Records
+            <span
+              className="pgn__hyperlink__external-icon"
+              title="Opens in a new tab"
+            >
+              <span
+                className="pgn__icon"
+                style={
+                  Object {
+                    "height": "1em",
+                    "width": "1em",
+                  }
+                }
+              >
+                <svg
+                  aria-hidden={true}
+                  fill="none"
+                  focusable={false}
+                  height={24}
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M19 19H5V5h7V3H3v18h18v-9h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span
+                  className="sr-only"
+                >
+                  in a new tab
+                </span>
+              </span>
+            </span>
+          </a>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Full Name
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye-slash fa-w-20 "
+                    data-icon="eye-slash"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 640 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M634 471L36 3.51A16 16 0 0 0 13.51 6l-10 12.49A16 16 0 0 0 6 41l598 467.49a16 16 0 0 0 22.49-2.49l10-12.49A16 16 0 0 0 634 471zM296.79 146.47l134.79 105.38C429.36 191.91 380.48 144 320 144a112.26 112.26 0 0 0-23.21 2.47zm46.42 219.07L208.42 260.16C210.65 320.09 259.53 368 320 368a113 113 0 0 0 23.21-2.46zM320 112c98.65 0 189.09 55 237.93 144a285.53 285.53 0 0 1-44 60.2l37.74 29.5a333.7 333.7 0 0 0 52.9-75.11 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64c-36.7 0-71.71 7-104.63 18.81l46.41 36.29c18.94-4.3 38.34-7.1 58.22-7.1zm0 288c-98.65 0-189.08-55-237.93-144a285.47 285.47 0 0 1 44.05-60.19l-37.74-29.5a333.6 333.6 0 0 0-52.89 75.1 32.35 32.35 0 0 0 0 29.19C89.72 376.41 197.08 448 320 448c36.7 0 71.71-7.05 104.63-18.81l-46.41-36.28C359.28 397.2 339.89 400 320 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Just me
+                </span>
+              </p>
+            </div>
+            <p
+              className="h5"
+              data-hj-suppress={true}
+            >
+              Lemon Seltzer
+            </p>
+            <small
+              className="form-text text-muted"
+            >
+              This is the name that appears in your account and on your certificates.
+            </small>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Location
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <p
+              className="h5"
+              data-hj-suppress={true}
+            >
+              Montenegro
+            </p>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Primary Language Spoken
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <p
+              className="h5"
+              data-hj-suppress={true}
+            >
+              Yoruba
+            </p>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              aria-labelledby="levelOfEducation-label"
+              role="dialog"
+            >
+              <form
+                onSubmit={[Function]}
+              >
+                <div
+                  className="pgn__form-group"
+                >
+                  <label
+                    className="edit-section-header"
+                    htmlFor="levelOfEducation"
+                  >
+                    Education
+                  </label>
+                  <select
+                    className="form-control"
+                    data-hj-suppress={true}
+                    id="levelOfEducation"
+                    name="levelOfEducation"
+                    onChange={[Function]}
+                    value="el"
+                  >
+                    <option
+                      value=""
+                    >
+                       
+                    </option>
+                    <option
+                      value="p"
+                    >
+                      Doctorate
+                    </option>
+                    <option
+                      value="m"
+                    >
+                      Master's or professional degree
+                    </option>
+                    <option
+                      value="b"
+                    >
+                      Bachelor's Degree
+                    </option>
+                    <option
+                      value="a"
+                    >
+                      Associate's degree
+                    </option>
+                    <option
+                      value="hs"
+                    >
+                      Secondary/high school
+                    </option>
+                    <option
+                      value="jhs"
+                    >
+                      Junior secondary/junior high/middle school
+                    </option>
+                    <option
+                      value="el"
+                    >
+                      Elementary/primary school
+                    </option>
+                    <option
+                      value="none"
+                    >
+                      No formal education
+                    </option>
+                    <option
+                      value="o"
+                    >
+                      Other education
+                    </option>
+                  </select>
+                  <div
+                    className="pgn__form-control-description pgn__form-text pgn__form-text-invalid"
+                    id="levelOfEducation-3"
+                  >
+                    education error
+                  </div>
+                </div>
+                <div
+                  className="d-flex flex-row-reverse flex-wrap justify-content-end align-items-center"
+                >
+                  <div
+                    className="form-group d-flex flex-wrap"
+                  >
+                    <label
+                      className="col-form-label"
+                      htmlFor="visibilityLevelOfEducation"
+                    >
+                      Who can see this:
+                    </label>
+                    <span
+                      className="d-flex align-items-center"
+                    >
+                      <span
+                        className="d-inline-block ml-1 mr-2"
+                        style={
+                          Object {
+                            "width": "1.5rem",
+                          }
+                        }
+                      >
+                        <svg
+                          aria-hidden="true"
+                          className="svg-inline--fa fa-eye-slash fa-w-20 "
+                          data-icon="eye-slash"
+                          data-prefix="far"
+                          focusable="false"
+                          role="img"
+                          style={Object {}}
+                          viewBox="0 0 640 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M634 471L36 3.51A16 16 0 0 0 13.51 6l-10 12.49A16 16 0 0 0 6 41l598 467.49a16 16 0 0 0 22.49-2.49l10-12.49A16 16 0 0 0 634 471zM296.79 146.47l134.79 105.38C429.36 191.91 380.48 144 320 144a112.26 112.26 0 0 0-23.21 2.47zm46.42 219.07L208.42 260.16C210.65 320.09 259.53 368 320 368a113 113 0 0 0 23.21-2.46zM320 112c98.65 0 189.09 55 237.93 144a285.53 285.53 0 0 1-44 60.2l37.74 29.5a333.7 333.7 0 0 0 52.9-75.11 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64c-36.7 0-71.71 7-104.63 18.81l46.41 36.29c18.94-4.3 38.34-7.1 58.22-7.1zm0 288c-98.65 0-189.08-55-237.93-144a285.47 285.47 0 0 1 44.05-60.19l-37.74-29.5a333.6 333.6 0 0 0-52.89 75.1 32.35 32.35 0 0 0 0 29.19C89.72 376.41 197.08 448 320 448c36.7 0 71.71-7.05 104.63-18.81l-46.41-36.28C359.28 397.2 339.89 400 320 400z"
+                            fill="currentColor"
+                            style={Object {}}
+                          />
+                        </svg>
+                      </span>
+                      <select
+                        className="d-inline-block w-auto form-control"
+                        id="visibilityLevelOfEducation"
+                        name="visibilityLevelOfEducation"
+                        onChange={[Function]}
+                        type="select"
+                        value="private"
+                      >
+                        <option
+                          value="private"
+                        >
+                          Just me
+                        </option>
+                        <option
+                          value="all_users"
+                        >
+                          Everyone on localhost
+                        </option>
+                      </select>
+                    </span>
+                  </div>
+                  <div
+                    className="form-group flex-shrink-0 flex-grow-1"
+                  >
+                    <button
+                      aria-disabled={false}
+                      aria-live="assertive"
+                      className="pgn__stateful-btn pgn__stateful-btn-state-pending btn btn-primary"
+                      disabled={false}
+                      onClick={[Function]}
+                      type="submit"
+                    >
+                      <span
+                        className="d-flex align-items-center justify-content-center"
+                      >
+                        <span
+                          className="pgn__stateful-btn-icon"
+                        >
+                          <span
+                            className="pgn__icon icon-spin"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="none"
+                              focusable={false}
+                              height={24}
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width={24}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M22 12A10 10 0 116.122 3.91l1.176 1.618A8 8 0 1020 12h2z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                        <span>
+                          Saving
+                        </span>
+                      </span>
+                    </button>
+                    <button
+                      className="btn btn-link"
+                      disabled={false}
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Social Links
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <ul
+              className="list-unstyled"
+            >
+              <li
+                className="form-group"
+              >
+                <a
+                  className="font-weight-bold"
+                  href="https://www.twitter.com/ALOHA"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-twitter fa-w-16 mr-2"
+                    data-icon="twitter"
+                    data-prefix="fab"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Twitter
+                </a>
+              </li>
+              <li
+                className="form-group"
+              >
+                <a
+                  className="font-weight-bold"
+                  href="https://www.facebook.com/aloha"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-facebook fa-w-16 mr-2"
+                    data-icon="facebook"
+                    data-prefix="fab"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256C504 119 393 8 256 8S8 119 8 256c0 123.78 90.69 226.38 209.25 245V327.69h-63V256h63v-54.64c0-62.15 37-96.48 93.67-96.48 27.14 0 55.52 4.84 55.52 4.84v61h-31.28c-30.8 0-40.41 19.12-40.41 38.73V256h68.78l-11 71.69h-57.78V501C413.31 482.38 504 379.78 504 256z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Facebook
+                </a>
+              </li>
+              <li
+                className="form-group"
+              >
+                <div>
+                  <button
+                    className="pl-0 text-left btn btn-link"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="svg-inline--fa fa-plus fa-w-14 fa-xs mr-2"
+                      data-icon="plus"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      style={Object {}}
+                      viewBox="0 0 448 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                        fill="currentColor"
+                        style={Object {}}
+                      />
+                    </svg>
+                    Add 
+                    LinkedIn
+                  </button>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pt-md-3 col-md-8 col-lg-7 offset-lg-1"
+      >
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                About Me
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <p
+              className="lead"
+              data-hj-suppress={true}
+            >
+              This is my bio
+            </p>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-4"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                My Certificates
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <div
+              className="row align-items-stretch"
+            >
+              <div
+                className="col col-sm-6 d-flex align-items-stretch"
+              >
+                <div
+                  className="card mb-4 certificate flex-grow-1"
+                >
+                  <div
+                    className="certificate-type-illustration"
+                    style={
+                      Object {
+                        "backgroundImage": "url(icon/mock/path)",
+                      }
+                    }
+                  />
+                  <div
+                    className="card-body d-flex flex-column"
+                  >
+                    <div
+                      className="card-title"
+                    >
+                      <p
+                        className="small mb-0"
+                      >
+                        Verified Certificate
+                      </p>
+                      <h4
+                        className="certificate-title"
+                      >
+                        edX Demonstration Course
+                      </h4>
+                    </div>
+                    <p
+                      className="small mb-0"
+                    >
+                      <span>
+                        From
+                      </span>
+                    </p>
+                    <p
+                      className="h6 mb-4"
+                    >
+                      edX
+                    </p>
+                    <div
+                      className="flex-grow-1"
+                    />
+                    <p
+                      className="small mb-2"
+                    >
+                      <span>
+                        Completed on 
+                        <span>
+                          3/4/2019
+                        </span>
+                      </span>
+                    </p>
+                    <div>
+                      <a
+                        className="pgn__hyperlink default-link standalone-link btn btn-outline-primary"
+                        href="http://www.example.com/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        View Certificate
+                        <span
+                          className="pgn__hyperlink__external-icon"
+                          title="Opens in a new tab"
+                        >
+                          <span
+                            className="pgn__icon"
+                            style={
+                              Object {
+                                "height": "1em",
+                                "width": "1em",
+                              }
+                            }
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="none"
+                              focusable={false}
+                              height={24}
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width={24}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M19 19H5V5h7V3H3v18h18v-9h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                            <span
+                              className="sr-only"
+                            >
+                              in a new tab
+                            </span>
+                          </span>
+                        </span>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<ProfilePage /> Renders correctly in various states test preferreded language edit with error 1`] = `
+<div
+  className="profile-page"
+>
+  <div
+    className="profile-page-bg-banner bg-primary d-none d-md-block p-relative"
+  />
+  <div
+    className="container-fluid"
+  >
+    <div
+      className="row align-items-center pt-4 mb-4 pt-md-0 mb-md-0"
+    >
+      <div
+        className="col-auto col-md-4 col-lg-3"
+      >
+        <div
+          className="d-flex align-items-center d-md-block"
+        >
+          <div
+            className="profile-avatar-wrap position-relative"
+          >
+            <div
+              className="profile-avatar rounded-circle bg-light"
+            >
+              <div
+                className="profile-avatar-menu-container"
+              >
+                <div
+                  className="dropdown"
+                  data-testid="dropdown"
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="dropdown-toggle btn btn-primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Change
+                  </button>
+                </div>
+              </div>
+              <img
+                alt="profile avatar"
+                className="w-100 h-100 d-block rounded-circle overflow-hidden"
+                data-hj-suppress={true}
+                src="http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_500.jpg?v=1552495012"
+                style={
+                  Object {
+                    "objectFit": "cover",
+                  }
+                }
+              />
+            </div>
+            <form
+              encType="multipart/form-data"
+              onSubmit={[Function]}
+            >
+              <input
+                accept=".jpg, .jpeg, .png"
+                className="d-none form-control-file"
+                id="photo-file"
+                name="file"
+                onChange={[Function]}
+                type="file"
+              />
+            </form>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col pl-0"
+      >
+        <div
+          className="d-md-none"
+        >
+          <span
+            data-hj-suppress={true}
+          >
+            <h1
+              className="h2 mb-0 font-weight-bold"
+            >
+              staff
+            </h1>
+            <p
+              className="mb-0"
+            >
+              <span>
+                Member since 
+                <span>
+                  2017
+                </span>
+              </span>
+            </p>
+            <hr
+              className="d-none d-md-block"
+            />
+          </span>
+        </div>
+        <div
+          className="d-none d-md-block float-right"
+        >
+          <a
+            className="pgn__hyperlink default-link standalone-link btn btn-primary"
+            href="http://localhost:18150/records"
+            onClick={[Function]}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            View My Records
+            <span
+              className="pgn__hyperlink__external-icon"
+              title="Opens in a new tab"
+            >
+              <span
+                className="pgn__icon"
+                style={
+                  Object {
+                    "height": "1em",
+                    "width": "1em",
+                  }
+                }
+              >
+                <svg
+                  aria-hidden={true}
+                  fill="none"
+                  focusable={false}
+                  height={24}
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M19 19H5V5h7V3H3v18h18v-9h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span
+                  className="sr-only"
+                >
+                  in a new tab
+                </span>
+              </span>
+            </span>
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      className="row"
+    >
+      <div
+        className="col-md-4 col-lg-4"
+      >
+        <div
+          className="d-none d-md-block mb-4"
+        >
+          <span
+            data-hj-suppress={true}
+          >
+            <h1
+              className="h2 mb-0 font-weight-bold"
+            >
+              staff
+            </h1>
+            <p
+              className="mb-0"
+            >
+              <span>
+                Member since 
+                <span>
+                  2017
+                </span>
+              </span>
+            </p>
+            <hr
+              className="d-none d-md-block"
+            />
+          </span>
+        </div>
+        <div
+          className="d-md-none mb-4"
+        >
+          <a
+            className="pgn__hyperlink default-link standalone-link btn btn-primary"
+            href="http://localhost:18150/records"
+            onClick={[Function]}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            View My Records
+            <span
+              className="pgn__hyperlink__external-icon"
+              title="Opens in a new tab"
+            >
+              <span
+                className="pgn__icon"
+                style={
+                  Object {
+                    "height": "1em",
+                    "width": "1em",
+                  }
+                }
+              >
+                <svg
+                  aria-hidden={true}
+                  fill="none"
+                  focusable={false}
+                  height={24}
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M19 19H5V5h7V3H3v18h18v-9h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span
+                  className="sr-only"
+                >
+                  in a new tab
+                </span>
+              </span>
+            </span>
+          </a>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Full Name
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye-slash fa-w-20 "
+                    data-icon="eye-slash"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 640 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M634 471L36 3.51A16 16 0 0 0 13.51 6l-10 12.49A16 16 0 0 0 6 41l598 467.49a16 16 0 0 0 22.49-2.49l10-12.49A16 16 0 0 0 634 471zM296.79 146.47l134.79 105.38C429.36 191.91 380.48 144 320 144a112.26 112.26 0 0 0-23.21 2.47zm46.42 219.07L208.42 260.16C210.65 320.09 259.53 368 320 368a113 113 0 0 0 23.21-2.46zM320 112c98.65 0 189.09 55 237.93 144a285.53 285.53 0 0 1-44 60.2l37.74 29.5a333.7 333.7 0 0 0 52.9-75.11 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64c-36.7 0-71.71 7-104.63 18.81l46.41 36.29c18.94-4.3 38.34-7.1 58.22-7.1zm0 288c-98.65 0-189.08-55-237.93-144a285.47 285.47 0 0 1 44.05-60.19l-37.74-29.5a333.6 333.6 0 0 0-52.89 75.1 32.35 32.35 0 0 0 0 29.19C89.72 376.41 197.08 448 320 448c36.7 0 71.71-7.05 104.63-18.81l-46.41-36.28C359.28 397.2 339.89 400 320 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Just me
+                </span>
+              </p>
+            </div>
+            <p
+              className="h5"
+              data-hj-suppress={true}
+            >
+              Lemon Seltzer
+            </p>
+            <small
+              className="form-text text-muted"
+            >
+              This is the name that appears in your account and on your certificates.
+            </small>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Location
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <p
+              className="h5"
+              data-hj-suppress={true}
+            >
+              Montenegro
+            </p>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              aria-labelledby="languageProficiencies-label"
+              role="dialog"
+            >
+              <form
+                onSubmit={[Function]}
+              >
+                <div
+                  className="pgn__form-group"
+                >
+                  <label
+                    className="edit-section-header"
+                    htmlFor="languageProficiencies"
+                  >
+                    Primary Language Spoken
+                  </label>
+                  <select
+                    className="form-control"
+                    data-hj-suppress={true}
+                    id="languageProficiencies"
+                    name="languageProficiencies"
+                    onChange={[Function]}
+                    value="yo"
+                  >
+                    <option
+                      value=""
+                    >
+                       
+                    </option>
+                    <option
+                      value="aa"
+                    >
+                      Afar
+                    </option>
+                    <option
+                      value="ab"
+                    >
+                      Abkhazian
+                    </option>
+                    <option
+                      value="ae"
+                    >
+                      Avestan
+                    </option>
+                    <option
+                      value="af"
+                    >
+                      Afrikaans
+                    </option>
+                    <option
+                      value="ak"
+                    >
+                      Akan
+                    </option>
+                    <option
+                      value="am"
+                    >
+                      Amharic
+                    </option>
+                    <option
+                      value="an"
+                    >
+                      Aragonese
+                    </option>
+                    <option
+                      value="ar"
+                    >
+                      Arabic
+                    </option>
+                    <option
+                      value="as"
+                    >
+                      Assamese
+                    </option>
+                    <option
+                      value="av"
+                    >
+                      Avaric
+                    </option>
+                    <option
+                      value="ay"
+                    >
+                      Aymara
+                    </option>
+                    <option
+                      value="az"
+                    >
+                      Azerbaijani
+                    </option>
+                    <option
+                      value="ba"
+                    >
+                      Bashkir
+                    </option>
+                    <option
+                      value="be"
+                    >
+                      Belarusian
+                    </option>
+                    <option
+                      value="bg"
+                    >
+                      Bulgarian
+                    </option>
+                    <option
+                      value="bh"
+                    >
+                      Bihari languages
+                    </option>
+                    <option
+                      value="bi"
+                    >
+                      Bislama
+                    </option>
+                    <option
+                      value="bm"
+                    >
+                      Bambara
+                    </option>
+                    <option
+                      value="bn"
+                    >
+                      Bengali
+                    </option>
+                    <option
+                      value="bo"
+                    >
+                      Tibetan
+                    </option>
+                    <option
+                      value="br"
+                    >
+                      Breton
+                    </option>
+                    <option
+                      value="bs"
+                    >
+                      Bosnian
+                    </option>
+                    <option
+                      value="ca"
+                    >
+                      Catalan
+                    </option>
+                    <option
+                      value="ce"
+                    >
+                      Chechen
+                    </option>
+                    <option
+                      value="ch"
+                    >
+                      Chamorro
+                    </option>
+                    <option
+                      value="co"
+                    >
+                      Corsican
+                    </option>
+                    <option
+                      value="cr"
+                    >
+                      Cree
+                    </option>
+                    <option
+                      value="cs"
+                    >
+                      Czech
+                    </option>
+                    <option
+                      value="cu"
+                    >
+                      Church Slavic
+                    </option>
+                    <option
+                      value="cv"
+                    >
+                      Chuvash
+                    </option>
+                    <option
+                      value="cy"
+                    >
+                      Welsh
+                    </option>
+                    <option
+                      value="da"
+                    >
+                      Danish
+                    </option>
+                    <option
+                      value="de"
+                    >
+                      German
+                    </option>
+                    <option
+                      value="dv"
+                    >
+                      Maldivian
+                    </option>
+                    <option
+                      value="dz"
+                    >
+                      Dzongkha
+                    </option>
+                    <option
+                      value="ee"
+                    >
+                      Ewe
+                    </option>
+                    <option
+                      value="el"
+                    >
+                      Greek (modern)
+                    </option>
+                    <option
+                      value="en"
+                    >
+                      English
+                    </option>
+                    <option
+                      value="eo"
+                    >
+                      Esperanto
+                    </option>
+                    <option
+                      value="es"
+                    >
+                      Spanish
+                    </option>
+                    <option
+                      value="et"
+                    >
+                      Estonian
+                    </option>
+                    <option
+                      value="eu"
+                    >
+                      Basque
+                    </option>
+                    <option
+                      value="fa"
+                    >
+                      Persian
+                    </option>
+                    <option
+                      value="ff"
+                    >
+                      Fulah
+                    </option>
+                    <option
+                      value="fi"
+                    >
+                      Finnish
+                    </option>
+                    <option
+                      value="fj"
+                    >
+                      Fijian
+                    </option>
+                    <option
+                      value="fo"
+                    >
+                      Faroese
+                    </option>
+                    <option
+                      value="fr"
+                    >
+                      French
+                    </option>
+                    <option
+                      value="fy"
+                    >
+                      Western Frisian
+                    </option>
+                    <option
+                      value="ga"
+                    >
+                      Irish
+                    </option>
+                    <option
+                      value="gd"
+                    >
+                      Gaelic
+                    </option>
+                    <option
+                      value="gl"
+                    >
+                      Galician
+                    </option>
+                    <option
+                      value="gn"
+                    >
+                      Guaraní
+                    </option>
+                    <option
+                      value="gu"
+                    >
+                      Gujarati
+                    </option>
+                    <option
+                      value="gv"
+                    >
+                      Manx
+                    </option>
+                    <option
+                      value="ha"
+                    >
+                      Hausa
+                    </option>
+                    <option
+                      value="he"
+                    >
+                      Hebrew (modern)
+                    </option>
+                    <option
+                      value="hi"
+                    >
+                      Hindi
+                    </option>
+                    <option
+                      value="ho"
+                    >
+                      Hiri Motu
+                    </option>
+                    <option
+                      value="hr"
+                    >
+                      Croatian
+                    </option>
+                    <option
+                      value="ht"
+                    >
+                      Haitian Creole
+                    </option>
+                    <option
+                      value="hu"
+                    >
+                      Hungarian
+                    </option>
+                    <option
+                      value="hy"
+                    >
+                      Armenian
+                    </option>
+                    <option
+                      value="hz"
+                    >
+                      Herero
+                    </option>
+                    <option
+                      value="ia"
+                    >
+                      Interlingua
+                    </option>
+                    <option
+                      value="id"
+                    >
+                      Indonesian
+                    </option>
+                    <option
+                      value="ie"
+                    >
+                      Interlingue
+                    </option>
+                    <option
+                      value="ig"
+                    >
+                      Igbo
+                    </option>
+                    <option
+                      value="ii"
+                    >
+                      Nuosu
+                    </option>
+                    <option
+                      value="ik"
+                    >
+                      Inupiaq
+                    </option>
+                    <option
+                      value="io"
+                    >
+                      Ido
+                    </option>
+                    <option
+                      value="is"
+                    >
+                      Icelandic
+                    </option>
+                    <option
+                      value="it"
+                    >
+                      Italian
+                    </option>
+                    <option
+                      value="iu"
+                    >
+                      Inuktitut
+                    </option>
+                    <option
+                      value="ja"
+                    >
+                      Japanese
+                    </option>
+                    <option
+                      value="jv"
+                    >
+                      Javanese
+                    </option>
+                    <option
+                      value="ka"
+                    >
+                      Georgian
+                    </option>
+                    <option
+                      value="kg"
+                    >
+                      Kongo
+                    </option>
+                    <option
+                      value="ki"
+                    >
+                      Kikuyu
+                    </option>
+                    <option
+                      value="kj"
+                    >
+                      Kwanyama
+                    </option>
+                    <option
+                      value="kk"
+                    >
+                      Kazakh
+                    </option>
+                    <option
+                      value="kl"
+                    >
+                      Greenlandic
+                    </option>
+                    <option
+                      value="km"
+                    >
+                      Central Khmer
+                    </option>
+                    <option
+                      value="kn"
+                    >
+                      Kannada
+                    </option>
+                    <option
+                      value="ko"
+                    >
+                      Korean
+                    </option>
+                    <option
+                      value="kr"
+                    >
+                      Kanuri
+                    </option>
+                    <option
+                      value="ks"
+                    >
+                      Kashmiri
+                    </option>
+                    <option
+                      value="ku"
+                    >
+                      Kurdish
+                    </option>
+                    <option
+                      value="kv"
+                    >
+                      Komi
+                    </option>
+                    <option
+                      value="kw"
+                    >
+                      Cornish
+                    </option>
+                    <option
+                      value="ky"
+                    >
+                      Kyrgyz
+                    </option>
+                    <option
+                      value="la"
+                    >
+                      Latin
+                    </option>
+                    <option
+                      value="lb"
+                    >
+                      Luxembourgish
+                    </option>
+                    <option
+                      value="lg"
+                    >
+                      Ganda
+                    </option>
+                    <option
+                      value="li"
+                    >
+                      Limburgish
+                    </option>
+                    <option
+                      value="ln"
+                    >
+                      Lingala
+                    </option>
+                    <option
+                      value="lo"
+                    >
+                      Lao
+                    </option>
+                    <option
+                      value="lt"
+                    >
+                      Lithuanian
+                    </option>
+                    <option
+                      value="lu"
+                    >
+                      Luba-Katanga
+                    </option>
+                    <option
+                      value="lv"
+                    >
+                      Latvian
+                    </option>
+                    <option
+                      value="mg"
+                    >
+                      Malagasy
+                    </option>
+                    <option
+                      value="mh"
+                    >
+                      Marshallese
+                    </option>
+                    <option
+                      value="mi"
+                    >
+                      Maori
+                    </option>
+                    <option
+                      value="mk"
+                    >
+                      Macedonian
+                    </option>
+                    <option
+                      value="ml"
+                    >
+                      Malayalam
+                    </option>
+                    <option
+                      value="mn"
+                    >
+                      Mongolian
+                    </option>
+                    <option
+                      value="mr"
+                    >
+                      Marathi
+                    </option>
+                    <option
+                      value="ms"
+                    >
+                      Malay
+                    </option>
+                    <option
+                      value="mt"
+                    >
+                      Maltese
+                    </option>
+                    <option
+                      value="my"
+                    >
+                      Burmese
+                    </option>
+                    <option
+                      value="na"
+                    >
+                      Nauru
+                    </option>
+                    <option
+                      value="nb"
+                    >
+                      Bokmål
+                    </option>
+                    <option
+                      value="nd"
+                    >
+                      North Ndebele
+                    </option>
+                    <option
+                      value="ne"
+                    >
+                      Nepali
+                    </option>
+                    <option
+                      value="ng"
+                    >
+                      Ndonga
+                    </option>
+                    <option
+                      value="nl"
+                    >
+                      Dutch
+                    </option>
+                    <option
+                      value="nn"
+                    >
+                      Norwegian Nynorsk
+                    </option>
+                    <option
+                      value="no"
+                    >
+                      Norwegian
+                    </option>
+                    <option
+                      value="nr"
+                    >
+                      South Ndebele
+                    </option>
+                    <option
+                      value="nv"
+                    >
+                      Navajo
+                    </option>
+                    <option
+                      value="ny"
+                    >
+                      Nyanja
+                    </option>
+                    <option
+                      value="oc"
+                    >
+                      Occitan
+                    </option>
+                    <option
+                      value="oj"
+                    >
+                      Ojibwa
+                    </option>
+                    <option
+                      value="om"
+                    >
+                      Oromo
+                    </option>
+                    <option
+                      value="or"
+                    >
+                      Oriya
+                    </option>
+                    <option
+                      value="os"
+                    >
+                      Ossetian
+                    </option>
+                    <option
+                      value="pa"
+                    >
+                      Punjabi
+                    </option>
+                    <option
+                      value="pi"
+                    >
+                      Pali
+                    </option>
+                    <option
+                      value="pl"
+                    >
+                      Polish
+                    </option>
+                    <option
+                      value="ps"
+                    >
+                      Pashto
+                    </option>
+                    <option
+                      value="pt"
+                    >
+                      Portuguese
+                    </option>
+                    <option
+                      value="qu"
+                    >
+                      Quechua
+                    </option>
+                    <option
+                      value="rm"
+                    >
+                      Romansh
+                    </option>
+                    <option
+                      value="rn"
+                    >
+                      Rundi
+                    </option>
+                    <option
+                      value="ro"
+                    >
+                      Romanian
+                    </option>
+                    <option
+                      value="ru"
+                    >
+                      Russian
+                    </option>
+                    <option
+                      value="rw"
+                    >
+                      Kinyarwanda
+                    </option>
+                    <option
+                      value="sa"
+                    >
+                      Sanskrit
+                    </option>
+                    <option
+                      value="sc"
+                    >
+                      Sardinian
+                    </option>
+                    <option
+                      value="sd"
+                    >
+                      Sindhi
+                    </option>
+                    <option
+                      value="se"
+                    >
+                      Northern Sami
+                    </option>
+                    <option
+                      value="sg"
+                    >
+                      Sango
+                    </option>
+                    <option
+                      value="si"
+                    >
+                      Sinhalese
+                    </option>
+                    <option
+                      value="sk"
+                    >
+                      Slovak
+                    </option>
+                    <option
+                      value="sl"
+                    >
+                      Slovenian
+                    </option>
+                    <option
+                      value="sm"
+                    >
+                      Samoan
+                    </option>
+                    <option
+                      value="sn"
+                    >
+                      Shona
+                    </option>
+                    <option
+                      value="so"
+                    >
+                      Somali
+                    </option>
+                    <option
+                      value="sq"
+                    >
+                      Albanian
+                    </option>
+                    <option
+                      value="sr"
+                    >
+                      Serbian
+                    </option>
+                    <option
+                      value="ss"
+                    >
+                      Swati
+                    </option>
+                    <option
+                      value="st"
+                    >
+                      Southern Sotho
+                    </option>
+                    <option
+                      value="su"
+                    >
+                      Sundanese
+                    </option>
+                    <option
+                      value="sv"
+                    >
+                      Swedish
+                    </option>
+                    <option
+                      value="sw"
+                    >
+                      Swahili
+                    </option>
+                    <option
+                      value="ta"
+                    >
+                      Tamil
+                    </option>
+                    <option
+                      value="te"
+                    >
+                      Telugu
+                    </option>
+                    <option
+                      value="tg"
+                    >
+                      Tajik
+                    </option>
+                    <option
+                      value="th"
+                    >
+                      Thai
+                    </option>
+                    <option
+                      value="ti"
+                    >
+                      Tigrinya
+                    </option>
+                    <option
+                      value="tk"
+                    >
+                      Turkmen
+                    </option>
+                    <option
+                      value="tl"
+                    >
+                      Tagalog
+                    </option>
+                    <option
+                      value="tn"
+                    >
+                      Tswana
+                    </option>
+                    <option
+                      value="to"
+                    >
+                      Tonga
+                    </option>
+                    <option
+                      value="tr"
+                    >
+                      Turkish
+                    </option>
+                    <option
+                      value="ts"
+                    >
+                      Tsonga
+                    </option>
+                    <option
+                      value="tt"
+                    >
+                      Tatar
+                    </option>
+                    <option
+                      value="tw"
+                    >
+                      Twi
+                    </option>
+                    <option
+                      value="ty"
+                    >
+                      Tahitian
+                    </option>
+                    <option
+                      value="ug"
+                    >
+                      Uyghur
+                    </option>
+                    <option
+                      value="uk"
+                    >
+                      Ukrainian
+                    </option>
+                    <option
+                      value="ur"
+                    >
+                      Urdu
+                    </option>
+                    <option
+                      value="uz"
+                    >
+                      Uzbek
+                    </option>
+                    <option
+                      value="ve"
+                    >
+                      Venda
+                    </option>
+                    <option
+                      value="vi"
+                    >
+                      Vietnamese
+                    </option>
+                    <option
+                      value="vo"
+                    >
+                      Volapük
+                    </option>
+                    <option
+                      value="wa"
+                    >
+                      Walloon
+                    </option>
+                    <option
+                      value="wo"
+                    >
+                      Wolof
+                    </option>
+                    <option
+                      value="xh"
+                    >
+                      Xhosa
+                    </option>
+                    <option
+                      value="yi"
+                    >
+                      Yiddish
+                    </option>
+                    <option
+                      value="yo"
+                    >
+                      Yoruba
+                    </option>
+                    <option
+                      value="za"
+                    >
+                      Zhuang
+                    </option>
+                    <option
+                      value="zh"
+                    >
+                      Chinese
+                    </option>
+                    <option
+                      value="zu"
+                    >
+                      Zulu
+                    </option>
+                  </select>
+                  <div
+                    className="pgn__form-control-description pgn__form-text pgn__form-text-invalid"
+                    id="languageProficiencies-4"
+                  >
+                    preferred language error
+                  </div>
+                </div>
+                <div
+                  className="d-flex flex-row-reverse flex-wrap justify-content-end align-items-center"
+                >
+                  <div
+                    className="form-group d-flex flex-wrap"
+                  >
+                    <label
+                      className="col-form-label"
+                      htmlFor="visibilityLanguageProficiencies"
+                    >
+                      Who can see this:
+                    </label>
+                    <span
+                      className="d-flex align-items-center"
+                    >
+                      <span
+                        className="d-inline-block ml-1 mr-2"
+                        style={
+                          Object {
+                            "width": "1.5rem",
+                          }
+                        }
+                      >
+                        <svg
+                          aria-hidden="true"
+                          className="svg-inline--fa fa-eye fa-w-18 "
+                          data-icon="eye"
+                          data-prefix="far"
+                          focusable="false"
+                          role="img"
+                          style={Object {}}
+                          viewBox="0 0 576 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                            fill="currentColor"
+                            style={Object {}}
+                          />
+                        </svg>
+                      </span>
+                      <select
+                        className="d-inline-block w-auto form-control"
+                        id="visibilityLanguageProficiencies"
+                        name="visibilityLanguageProficiencies"
+                        onChange={[Function]}
+                        type="select"
+                        value="all_users"
+                      >
+                        <option
+                          value="private"
+                        >
+                          Just me
+                        </option>
+                        <option
+                          value="all_users"
+                        >
+                          Everyone on localhost
+                        </option>
+                      </select>
+                    </span>
+                  </div>
+                  <div
+                    className="form-group flex-shrink-0 flex-grow-1"
+                  >
+                    <button
+                      aria-disabled={false}
+                      aria-live="assertive"
+                      className="pgn__stateful-btn pgn__stateful-btn-state-pending btn btn-primary"
+                      disabled={false}
+                      onClick={[Function]}
+                      type="submit"
+                    >
+                      <span
+                        className="d-flex align-items-center justify-content-center"
+                      >
+                        <span
+                          className="pgn__stateful-btn-icon"
+                        >
+                          <span
+                            className="pgn__icon icon-spin"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="none"
+                              focusable={false}
+                              height={24}
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width={24}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M22 12A10 10 0 116.122 3.91l1.176 1.618A8 8 0 1020 12h2z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                        <span>
+                          Saving
+                        </span>
+                      </span>
+                    </button>
+                    <button
+                      className="btn btn-link"
+                      disabled={false}
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Education
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye-slash fa-w-20 "
+                    data-icon="eye-slash"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 640 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M634 471L36 3.51A16 16 0 0 0 13.51 6l-10 12.49A16 16 0 0 0 6 41l598 467.49a16 16 0 0 0 22.49-2.49l10-12.49A16 16 0 0 0 634 471zM296.79 146.47l134.79 105.38C429.36 191.91 380.48 144 320 144a112.26 112.26 0 0 0-23.21 2.47zm46.42 219.07L208.42 260.16C210.65 320.09 259.53 368 320 368a113 113 0 0 0 23.21-2.46zM320 112c98.65 0 189.09 55 237.93 144a285.53 285.53 0 0 1-44 60.2l37.74 29.5a333.7 333.7 0 0 0 52.9-75.11 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64c-36.7 0-71.71 7-104.63 18.81l46.41 36.29c18.94-4.3 38.34-7.1 58.22-7.1zm0 288c-98.65 0-189.08-55-237.93-144a285.47 285.47 0 0 1 44.05-60.19l-37.74-29.5a333.6 333.6 0 0 0-52.89 75.1 32.35 32.35 0 0 0 0 29.19C89.72 376.41 197.08 448 320 448c36.7 0 71.71-7.05 104.63-18.81l-46.41-36.28C359.28 397.2 339.89 400 320 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Just me
+                </span>
+              </p>
+            </div>
+            <p
+              className="h5"
+              data-hj-suppress={true}
+            >
+              Elementary/primary school
+            </p>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Social Links
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <ul
+              className="list-unstyled"
+            >
+              <li
+                className="form-group"
+              >
+                <a
+                  className="font-weight-bold"
+                  href="https://www.twitter.com/ALOHA"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-twitter fa-w-16 mr-2"
+                    data-icon="twitter"
+                    data-prefix="fab"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Twitter
+                </a>
+              </li>
+              <li
+                className="form-group"
+              >
+                <a
+                  className="font-weight-bold"
+                  href="https://www.facebook.com/aloha"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-facebook fa-w-16 mr-2"
+                    data-icon="facebook"
+                    data-prefix="fab"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256C504 119 393 8 256 8S8 119 8 256c0 123.78 90.69 226.38 209.25 245V327.69h-63V256h63v-54.64c0-62.15 37-96.48 93.67-96.48 27.14 0 55.52 4.84 55.52 4.84v61h-31.28c-30.8 0-40.41 19.12-40.41 38.73V256h68.78l-11 71.69h-57.78V501C413.31 482.38 504 379.78 504 256z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Facebook
+                </a>
+              </li>
+              <li
+                className="form-group"
+              >
+                <div>
+                  <button
+                    className="pl-0 text-left btn btn-link"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="svg-inline--fa fa-plus fa-w-14 fa-xs mr-2"
+                      data-icon="plus"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      style={Object {}}
+                      viewBox="0 0 448 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                        fill="currentColor"
+                        style={Object {}}
+                      />
+                    </svg>
+                    Add 
+                    LinkedIn
+                  </button>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pt-md-3 col-md-8 col-lg-7 offset-lg-1"
+      >
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                About Me
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <p
+              className="lead"
+              data-hj-suppress={true}
+            >
+              This is my bio
+            </p>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-4"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                My Certificates
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <div
+              className="row align-items-stretch"
+            >
+              <div
+                className="col col-sm-6 d-flex align-items-stretch"
+              >
+                <div
+                  className="card mb-4 certificate flex-grow-1"
+                >
+                  <div
+                    className="certificate-type-illustration"
+                    style={
+                      Object {
+                        "backgroundImage": "url(icon/mock/path)",
+                      }
+                    }
+                  />
+                  <div
+                    className="card-body d-flex flex-column"
+                  >
+                    <div
+                      className="card-title"
+                    >
+                      <p
+                        className="small mb-0"
+                      >
+                        Verified Certificate
+                      </p>
+                      <h4
+                        className="certificate-title"
+                      >
+                        edX Demonstration Course
+                      </h4>
+                    </div>
+                    <p
+                      className="small mb-0"
+                    >
+                      <span>
+                        From
+                      </span>
+                    </p>
+                    <p
+                      className="h6 mb-4"
+                    >
+                      edX
+                    </p>
+                    <div
+                      className="flex-grow-1"
+                    />
+                    <p
+                      className="small mb-2"
+                    >
+                      <span>
+                        Completed on 
+                        <span>
+                          3/4/2019
+                        </span>
+                      </span>
+                    </p>
+                    <div>
+                      <a
+                        className="pgn__hyperlink default-link standalone-link btn btn-outline-primary"
+                        href="http://www.example.com/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        View Certificate
+                        <span
+                          className="pgn__hyperlink__external-icon"
+                          title="Opens in a new tab"
+                        >
+                          <span
+                            className="pgn__icon"
+                            style={
+                              Object {
+                                "height": "1em",
+                                "width": "1em",
+                              }
+                            }
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="none"
+                              focusable={false}
+                              height={24}
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width={24}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M19 19H5V5h7V3H3v18h18v-9h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                            <span
+                              className="sr-only"
+                            >
+                              in a new tab
+                            </span>
+                          </span>
+                        </span>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<ProfilePage /> Renders correctly in various states viewing other profile 1`] = `
 <div
   className="profile-page"
@@ -2152,6 +7800,1143 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
                     onChange={[Function]}
                     value="This is my bio"
                   />
+                </div>
+                <div
+                  className="d-flex flex-row-reverse flex-wrap justify-content-end align-items-center"
+                >
+                  <div
+                    className="form-group d-flex flex-wrap"
+                  >
+                    <label
+                      className="col-form-label"
+                      htmlFor="visibilityBio"
+                    >
+                      Who can see this:
+                    </label>
+                    <span
+                      className="d-flex align-items-center"
+                    >
+                      <span
+                        className="d-inline-block ml-1 mr-2"
+                        style={
+                          Object {
+                            "width": "1.5rem",
+                          }
+                        }
+                      >
+                        <svg
+                          aria-hidden="true"
+                          className="svg-inline--fa fa-eye fa-w-18 "
+                          data-icon="eye"
+                          data-prefix="far"
+                          focusable="false"
+                          role="img"
+                          style={Object {}}
+                          viewBox="0 0 576 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                            fill="currentColor"
+                            style={Object {}}
+                          />
+                        </svg>
+                      </span>
+                      <select
+                        className="d-inline-block w-auto form-control"
+                        id="visibilityBio"
+                        name="visibilityBio"
+                        onChange={[Function]}
+                        type="select"
+                        value="all_users"
+                      >
+                        <option
+                          value="private"
+                        >
+                          Just me
+                        </option>
+                        <option
+                          value="all_users"
+                        >
+                          Everyone on localhost
+                        </option>
+                      </select>
+                    </span>
+                  </div>
+                  <div
+                    className="form-group flex-shrink-0 flex-grow-1"
+                  >
+                    <button
+                      aria-disabled={false}
+                      aria-live="assertive"
+                      className="pgn__stateful-btn pgn__stateful-btn-state-pending btn btn-primary"
+                      disabled={false}
+                      onClick={[Function]}
+                      type="submit"
+                    >
+                      <span
+                        className="d-flex align-items-center justify-content-center"
+                      >
+                        <span
+                          className="pgn__stateful-btn-icon"
+                        >
+                          <span
+                            className="pgn__icon icon-spin"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="none"
+                              focusable={false}
+                              height={24}
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width={24}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M22 12A10 10 0 116.122 3.91l1.176 1.618A8 8 0 1020 12h2z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                        <span>
+                          Saving
+                        </span>
+                      </span>
+                    </button>
+                    <button
+                      className="btn btn-link"
+                      disabled={false}
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-4"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                My Certificates
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <div
+              className="row align-items-stretch"
+            >
+              <div
+                className="col col-sm-6 d-flex align-items-stretch"
+              >
+                <div
+                  className="card mb-4 certificate flex-grow-1"
+                >
+                  <div
+                    className="certificate-type-illustration"
+                    style={
+                      Object {
+                        "backgroundImage": "url(icon/mock/path)",
+                      }
+                    }
+                  />
+                  <div
+                    className="card-body d-flex flex-column"
+                  >
+                    <div
+                      className="card-title"
+                    >
+                      <p
+                        className="small mb-0"
+                      >
+                        Verified Certificate
+                      </p>
+                      <h4
+                        className="certificate-title"
+                      >
+                        edX Demonstration Course
+                      </h4>
+                    </div>
+                    <p
+                      className="small mb-0"
+                    >
+                      <span>
+                        From
+                      </span>
+                    </p>
+                    <p
+                      className="h6 mb-4"
+                    >
+                      edX
+                    </p>
+                    <div
+                      className="flex-grow-1"
+                    />
+                    <p
+                      className="small mb-2"
+                    >
+                      <span>
+                        Completed on 
+                        <span>
+                          3/4/2019
+                        </span>
+                      </span>
+                    </p>
+                    <div>
+                      <a
+                        className="pgn__hyperlink default-link standalone-link btn btn-outline-primary"
+                        href="http://www.example.com/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        View Certificate
+                        <span
+                          className="pgn__hyperlink__external-icon"
+                          title="Opens in a new tab"
+                        >
+                          <span
+                            className="pgn__icon"
+                            style={
+                              Object {
+                                "height": "1em",
+                                "width": "1em",
+                              }
+                            }
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="none"
+                              focusable={false}
+                              height={24}
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width={24}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M19 19H5V5h7V3H3v18h18v-9h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                            <span
+                              className="sr-only"
+                            >
+                              in a new tab
+                            </span>
+                          </span>
+                        </span>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<ProfilePage /> Renders correctly in various states while saving an edited bio with error 1`] = `
+<div
+  className="profile-page"
+>
+  <div
+    className="profile-page-bg-banner bg-primary d-none d-md-block p-relative"
+  />
+  <div
+    className="container-fluid"
+  >
+    <div
+      className="row align-items-center pt-4 mb-4 pt-md-0 mb-md-0"
+    >
+      <div
+        className="col-auto col-md-4 col-lg-3"
+      >
+        <div
+          className="d-flex align-items-center d-md-block"
+        >
+          <div
+            className="profile-avatar-wrap position-relative"
+          >
+            <div
+              className="profile-avatar rounded-circle bg-light"
+            >
+              <div
+                className="profile-avatar-menu-container"
+              >
+                <div
+                  className="dropdown"
+                  data-testid="dropdown"
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="dropdown-toggle btn btn-primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Change
+                  </button>
+                </div>
+              </div>
+              <img
+                alt="profile avatar"
+                className="w-100 h-100 d-block rounded-circle overflow-hidden"
+                data-hj-suppress={true}
+                src="http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_500.jpg?v=1552495012"
+                style={
+                  Object {
+                    "objectFit": "cover",
+                  }
+                }
+              />
+            </div>
+            <form
+              encType="multipart/form-data"
+              onSubmit={[Function]}
+            >
+              <input
+                accept=".jpg, .jpeg, .png"
+                className="d-none form-control-file"
+                id="photo-file"
+                name="file"
+                onChange={[Function]}
+                type="file"
+              />
+            </form>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col pl-0"
+      >
+        <div
+          className="d-md-none"
+        >
+          <span
+            data-hj-suppress={true}
+          >
+            <h1
+              className="h2 mb-0 font-weight-bold"
+            >
+              staff
+            </h1>
+            <p
+              className="mb-0"
+            >
+              <span>
+                Member since 
+                <span>
+                  2017
+                </span>
+              </span>
+            </p>
+            <hr
+              className="d-none d-md-block"
+            />
+          </span>
+        </div>
+        <div
+          className="d-none d-md-block float-right"
+        >
+          <a
+            className="pgn__hyperlink default-link standalone-link btn btn-primary"
+            href="http://localhost:18150/records"
+            onClick={[Function]}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            View My Records
+            <span
+              className="pgn__hyperlink__external-icon"
+              title="Opens in a new tab"
+            >
+              <span
+                className="pgn__icon"
+                style={
+                  Object {
+                    "height": "1em",
+                    "width": "1em",
+                  }
+                }
+              >
+                <svg
+                  aria-hidden={true}
+                  fill="none"
+                  focusable={false}
+                  height={24}
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M19 19H5V5h7V3H3v18h18v-9h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span
+                  className="sr-only"
+                >
+                  in a new tab
+                </span>
+              </span>
+            </span>
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      className="row"
+    >
+      <div
+        className="col-md-4 col-lg-4"
+      >
+        <div
+          className="d-none d-md-block mb-4"
+        >
+          <span
+            data-hj-suppress={true}
+          >
+            <h1
+              className="h2 mb-0 font-weight-bold"
+            >
+              staff
+            </h1>
+            <p
+              className="mb-0"
+            >
+              <span>
+                Member since 
+                <span>
+                  2017
+                </span>
+              </span>
+            </p>
+            <hr
+              className="d-none d-md-block"
+            />
+          </span>
+        </div>
+        <div
+          className="d-md-none mb-4"
+        >
+          <a
+            className="pgn__hyperlink default-link standalone-link btn btn-primary"
+            href="http://localhost:18150/records"
+            onClick={[Function]}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            View My Records
+            <span
+              className="pgn__hyperlink__external-icon"
+              title="Opens in a new tab"
+            >
+              <span
+                className="pgn__icon"
+                style={
+                  Object {
+                    "height": "1em",
+                    "width": "1em",
+                  }
+                }
+              >
+                <svg
+                  aria-hidden={true}
+                  fill="none"
+                  focusable={false}
+                  height={24}
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M19 19H5V5h7V3H3v18h18v-9h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span
+                  className="sr-only"
+                >
+                  in a new tab
+                </span>
+              </span>
+            </span>
+          </a>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Full Name
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye-slash fa-w-20 "
+                    data-icon="eye-slash"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 640 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M634 471L36 3.51A16 16 0 0 0 13.51 6l-10 12.49A16 16 0 0 0 6 41l598 467.49a16 16 0 0 0 22.49-2.49l10-12.49A16 16 0 0 0 634 471zM296.79 146.47l134.79 105.38C429.36 191.91 380.48 144 320 144a112.26 112.26 0 0 0-23.21 2.47zm46.42 219.07L208.42 260.16C210.65 320.09 259.53 368 320 368a113 113 0 0 0 23.21-2.46zM320 112c98.65 0 189.09 55 237.93 144a285.53 285.53 0 0 1-44 60.2l37.74 29.5a333.7 333.7 0 0 0 52.9-75.11 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64c-36.7 0-71.71 7-104.63 18.81l46.41 36.29c18.94-4.3 38.34-7.1 58.22-7.1zm0 288c-98.65 0-189.08-55-237.93-144a285.47 285.47 0 0 1 44.05-60.19l-37.74-29.5a333.6 333.6 0 0 0-52.89 75.1 32.35 32.35 0 0 0 0 29.19C89.72 376.41 197.08 448 320 448c36.7 0 71.71-7.05 104.63-18.81l-46.41-36.28C359.28 397.2 339.89 400 320 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Just me
+                </span>
+              </p>
+            </div>
+            <p
+              className="h5"
+              data-hj-suppress={true}
+            >
+              Lemon Seltzer
+            </p>
+            <small
+              className="form-text text-muted"
+            >
+              This is the name that appears in your account and on your certificates.
+            </small>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Location
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <p
+              className="h5"
+              data-hj-suppress={true}
+            >
+              Montenegro
+            </p>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Primary Language Spoken
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <p
+              className="h5"
+              data-hj-suppress={true}
+            >
+              Yoruba
+            </p>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Education
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye-slash fa-w-20 "
+                    data-icon="eye-slash"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 640 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M634 471L36 3.51A16 16 0 0 0 13.51 6l-10 12.49A16 16 0 0 0 6 41l598 467.49a16 16 0 0 0 22.49-2.49l10-12.49A16 16 0 0 0 634 471zM296.79 146.47l134.79 105.38C429.36 191.91 380.48 144 320 144a112.26 112.26 0 0 0-23.21 2.47zm46.42 219.07L208.42 260.16C210.65 320.09 259.53 368 320 368a113 113 0 0 0 23.21-2.46zM320 112c98.65 0 189.09 55 237.93 144a285.53 285.53 0 0 1-44 60.2l37.74 29.5a333.7 333.7 0 0 0 52.9-75.11 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64c-36.7 0-71.71 7-104.63 18.81l46.41 36.29c18.94-4.3 38.34-7.1 58.22-7.1zm0 288c-98.65 0-189.08-55-237.93-144a285.47 285.47 0 0 1 44.05-60.19l-37.74-29.5a333.6 333.6 0 0 0-52.89 75.1 32.35 32.35 0 0 0 0 29.19C89.72 376.41 197.08 448 320 448c36.7 0 71.71-7.05 104.63-18.81l-46.41-36.28C359.28 397.2 339.89 400 320 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Just me
+                </span>
+              </p>
+            </div>
+            <p
+              className="h5"
+              data-hj-suppress={true}
+            >
+              Elementary/primary school
+            </p>
+          </div>
+        </div>
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              className="editable-item-header mb-2"
+            >
+              <h2
+                className="edit-section-header"
+                id={null}
+              >
+                Social Links
+                <button
+                  className="float-right px-0 btn btn-link btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginTop": "-.35rem",
+                    }
+                  }
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-pencil-alt fa-w-16 mr-1"
+                    data-icon="pencil-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Edit
+                </button>
+              </h2>
+              <p
+                className="mb-0"
+              >
+                <span
+                  className="ml-auto small text-muted"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-eye fa-w-18 "
+                    data-icon="eye"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 576 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                   
+                  Everyone on localhost
+                </span>
+              </p>
+            </div>
+            <ul
+              className="list-unstyled"
+            >
+              <li
+                className="form-group"
+              >
+                <a
+                  className="font-weight-bold"
+                  href="https://www.twitter.com/ALOHA"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-twitter fa-w-16 mr-2"
+                    data-icon="twitter"
+                    data-prefix="fab"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Twitter
+                </a>
+              </li>
+              <li
+                className="form-group"
+              >
+                <a
+                  className="font-weight-bold"
+                  href="https://www.facebook.com/aloha"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-facebook fa-w-16 mr-2"
+                    data-icon="facebook"
+                    data-prefix="fab"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256C504 119 393 8 256 8S8 119 8 256c0 123.78 90.69 226.38 209.25 245V327.69h-63V256h63v-54.64c0-62.15 37-96.48 93.67-96.48 27.14 0 55.52 4.84 55.52 4.84v61h-31.28c-30.8 0-40.41 19.12-40.41 38.73V256h68.78l-11 71.69h-57.78V501C413.31 482.38 504 379.78 504 256z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                  Facebook
+                </a>
+              </li>
+              <li
+                className="form-group"
+              >
+                <div>
+                  <button
+                    className="pl-0 text-left btn btn-link"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="svg-inline--fa fa-plus fa-w-14 fa-xs mr-2"
+                      data-icon="plus"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      style={Object {}}
+                      viewBox="0 0 448 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                        fill="currentColor"
+                        style={Object {}}
+                      />
+                    </svg>
+                    Add 
+                    LinkedIn
+                  </button>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pt-md-3 col-md-8 col-lg-7 offset-lg-1"
+      >
+        <div
+          className="pgn-transition-replace-group position-relative mb-5"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "padding": ".1px 0",
+              }
+            }
+          >
+            <div
+              aria-labelledby="bio-label"
+              role="dialog"
+            >
+              <form
+                onSubmit={[Function]}
+              >
+                <div
+                  className="pgn__form-group"
+                >
+                  <label
+                    className="edit-section-header"
+                    htmlFor="bio"
+                  >
+                    About Me
+                  </label>
+                  <textarea
+                    className="form-control"
+                    id="bio"
+                    name="bio"
+                    onChange={[Function]}
+                    value="This is my bio"
+                  />
+                  <div
+                    className="pgn__form-control-description pgn__form-text pgn__form-text-invalid"
+                    id="bio-1"
+                  >
+                    bio error
+                  </div>
                 </div>
                 <div
                   className="d-flex flex-row-reverse flex-wrap justify-content-end align-items-center"

--- a/src/profile/forms/Bio.jsx
+++ b/src/profile/forms/Bio.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { ValidationFormGroup } from '@edx/paragon';
+import { Form } from '@edx/paragon';
 
 import messages from './Bio.messages';
 
@@ -56,10 +56,9 @@ class Bio extends React.Component {
           editing: (
             <div role="dialog" aria-labelledby={`${formId}-label`}>
               <form onSubmit={this.handleSubmit}>
-                <ValidationFormGroup
-                  for={formId}
-                  invalid={error !== null}
-                  invalidMessage={error}
+                <Form.Group
+                  controlId={formId}
+                  isInvalid={error !== null}
                 >
                   <label className="edit-section-header" htmlFor={formId}>
                     {intl.formatMessage(messages['profile.bio.about.me'])}
@@ -71,7 +70,12 @@ class Bio extends React.Component {
                     value={bio}
                     onChange={this.handleChange}
                   />
-                </ValidationFormGroup>
+                  {error !== null && (
+                    <Form.Control.Feedback hasIcon={false} >
+                      {error}
+                    </Form.Control.Feedback>
+                  )}
+                </Form.Group>
                 <FormControls
                   visibilityId="visibilityBio"
                   saveState={saveState}

--- a/src/profile/forms/Bio.jsx
+++ b/src/profile/forms/Bio.jsx
@@ -71,7 +71,7 @@ class Bio extends React.Component {
                     onChange={this.handleChange}
                   />
                   {error !== null && (
-                    <Form.Control.Feedback hasIcon={false} >
+                    <Form.Control.Feedback hasIcon={false}>
                       {error}
                     </Form.Control.Feedback>
                   )}

--- a/src/profile/forms/Country.jsx
+++ b/src/profile/forms/Country.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { ValidationFormGroup } from '@edx/paragon';
+import { Form } from '@edx/paragon';
 
 import messages from './Country.messages';
 
@@ -67,10 +67,9 @@ class Country extends React.Component {
           editing: (
             <div role="dialog" aria-labelledby={`${formId}-label`}>
               <form onSubmit={this.handleSubmit}>
-                <ValidationFormGroup
-                  for={formId}
-                  invalid={error !== null}
-                  invalidMessage={error}
+                <Form.Group
+                  controlId={formId}
+                  isInvalid={error !== null}
                 >
                   <label className="edit-section-header" htmlFor={formId}>
                     {intl.formatMessage(messages['profile.country.label'])}
@@ -89,7 +88,12 @@ class Country extends React.Component {
                       <option key={code} value={code}>{name}</option>
                     ))}
                   </select>
-                </ValidationFormGroup>
+                  {error !== null && (
+                    <Form.Control.Feedback hasIcon={false} >
+                      {error}
+                    </Form.Control.Feedback>
+                  )}
+                </Form.Group>
                 <FormControls
                   visibilityId="visibilityCountry"
                   saveState={saveState}

--- a/src/profile/forms/Country.jsx
+++ b/src/profile/forms/Country.jsx
@@ -89,7 +89,7 @@ class Country extends React.Component {
                     ))}
                   </select>
                   {error !== null && (
-                    <Form.Control.Feedback hasIcon={false} >
+                    <Form.Control.Feedback hasIcon={false}>
                       {error}
                     </Form.Control.Feedback>
                   )}

--- a/src/profile/forms/Education.jsx
+++ b/src/profile/forms/Education.jsx
@@ -90,7 +90,7 @@ class Education extends React.Component {
                     ))}
                   </select>
                   {error !== null && (
-                    <Form.Control.Feedback hasIcon={false} >
+                    <Form.Control.Feedback hasIcon={false}>
                       {error}
                     </Form.Control.Feedback>
                   )}

--- a/src/profile/forms/Education.jsx
+++ b/src/profile/forms/Education.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import get from 'lodash.get';
-import { ValidationFormGroup } from '@edx/paragon';
+import { Form } from '@edx/paragon';
 
 import messages from './Education.messages';
 
@@ -63,10 +63,9 @@ class Education extends React.Component {
           editing: (
             <div role="dialog" aria-labelledby={`${formId}-label`}>
               <form onSubmit={this.handleSubmit}>
-                <ValidationFormGroup
-                  for={formId}
-                  invalid={error !== null}
-                  invalidMessage={error}
+                <Form.Group
+                  controlId={formId}
+                  isInvalid={error !== null}
                 >
                   <label className="edit-section-header" htmlFor={formId}>
                     {intl.formatMessage(messages['profile.education.education'])}
@@ -90,7 +89,12 @@ class Education extends React.Component {
                       </option>
                     ))}
                   </select>
-                </ValidationFormGroup>
+                  {error !== null && (
+                    <Form.Control.Feedback hasIcon={false} >
+                      {error}
+                    </Form.Control.Feedback>
+                  )}
+                </Form.Group>
                 <FormControls
                   visibilityId="visibilityLevelOfEducation"
                   saveState={saveState}

--- a/src/profile/forms/PreferredLanguage.jsx
+++ b/src/profile/forms/PreferredLanguage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { ValidationFormGroup } from '@edx/paragon';
+import { Form } from '@edx/paragon';
 
 import messages from './PreferredLanguage.messages';
 
@@ -77,10 +77,9 @@ class PreferredLanguage extends React.Component {
           editing: (
             <div role="dialog" aria-labelledby={`${formId}-label`}>
               <form onSubmit={this.handleSubmit}>
-                <ValidationFormGroup
-                  for={formId}
-                  invalid={error !== null}
-                  invalidMessage={error}
+                <Form.Group
+                  controlId={formId}
+                  isInvalid={error !== null}
                 >
                   <label className="edit-section-header" htmlFor={formId}>
                     {intl.formatMessage(messages['profile.preferredlanguage.label'])}
@@ -98,7 +97,12 @@ class PreferredLanguage extends React.Component {
                       <option key={code} value={code}>{name}</option>
                     ))}
                   </select>
-                </ValidationFormGroup>
+                  {error !== null && (
+                    <Form.Control.Feedback hasIcon={false} >
+                      {error}
+                    </Form.Control.Feedback>
+                  )}
+                </Form.Group>
                 <FormControls
                   visibilityId="visibilityLanguageProficiencies"
                   saveState={saveState}

--- a/src/profile/forms/PreferredLanguage.jsx
+++ b/src/profile/forms/PreferredLanguage.jsx
@@ -98,7 +98,7 @@ class PreferredLanguage extends React.Component {
                     ))}
                   </select>
                   {error !== null && (
-                    <Form.Control.Feedback hasIcon={false} >
+                    <Form.Control.Feedback hasIcon={false}>
                       {error}
                     </Form.Control.Feedback>
                   )}


### PR DESCRIPTION
### Ticket
[Migrate off deprecated Paragon components](https://github.com/openedx/frontend-wg/issues/102#)

### What has changed
Updated deprecated `ValidationFormGroup` to `Form.Group`, `Input` to `Form.Control` and `Checkbox` to `Form. CheckBox`.
Tested on edx.org theme.

### Screenshots
![image](https://user-images.githubusercontent.com/42172960/182534425-76d1d8fa-a7e0-4653-b9b5-de7ae02c579d.png)

![image](https://user-images.githubusercontent.com/42172960/182534508-ffaa8471-7b3f-4d71-a0a7-f30ada33fbcf.png)
