### PR TITLE
build: use shared browserslist configuration and upgrade paragon version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         npm-test:
         - i18n_extract
-        - is-es6
         - lint
         - test
         node: [16]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         npm-test:
         - i18n_extract
-        - is-es5
+        - is-es6
         - lint
         - test
         node: [16]

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transi
 # This directory must match .babelrc .
 transifex_temp = ./temp/babel-plugin-react-intl
 
-NPM_TESTS=build i18n_extract lint test is-es5
+NPM_TESTS=build i18n_extract lint test
 
 .PHONY: test
 test: $(addprefix test.npm.,$(NPM_TESTS))  ## validate ci suite

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/frontend-component-footer": "11.5.2",
         "@edx/frontend-component-header": "3.5.0",
         "@edx/frontend-platform": "2.6.2",
-        "@edx/paragon": "19.25.3",
+        "@edx/paragon": "^20.20.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-brands-svg-icons": "5.15.4",
         "@fortawesome/free-regular-svg-icons": "5.15.4",
@@ -44,12 +44,12 @@
       "devDependencies": {
         "@commitlint/cli": "17.3.0",
         "@commitlint/config-angular": "17.3.0",
+        "@edx/browserslist-config": "^1.1.1",
         "@edx/frontend-build": "12.0.6",
         "@edx/reactifex": "2.1.1",
         "codecov": "3.8.3",
         "enzyme": "3.11.0",
         "enzyme-adapter-react-16": "1.15.7",
-        "es-check": "5.2.4",
         "glob": "7.2.3",
         "react-test-renderer": "16.14.0",
         "reactifex": "1.1.1",
@@ -2208,6 +2208,12 @@
       "version": "1.1.0",
       "license": "GPL-3.0-or-later"
     },
+    "node_modules/@edx/browserslist-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.1.1.tgz",
+      "integrity": "sha512-baLX2wxguWNXLIAi26l/iUIJoI9T8LVDH+8+3xP3HjFtWSCOVjz19sgxx4PlWwwMkbUkVmfuxrm2XVueqI6xLw==",
+      "dev": true
+    },
     "node_modules/@edx/eslint-config": {
       "version": "3.1.0",
       "dev": true,
@@ -2413,32 +2419,59 @@
       }
     },
     "node_modules/@edx/paragon": {
-      "version": "19.25.3",
-      "license": "Apache-2.0",
+      "version": "20.20.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.20.0.tgz",
+      "integrity": "sha512-spoEuQgRA0pf4Lg3O9a5qjePbf9dWlg206+l5WPNZtDVdBzqoxFdn9vL47GPNJRP4ksHfpTDLdmIkgX7t1TngQ==",
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^1.2.36",
+        "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
         "@popperjs/core": "^2.11.4",
-        "bootstrap": "^4.6.1",
+        "bootstrap": "^4.6.2",
         "classnames": "^2.3.1",
         "email-prop-type": "^3.0.0",
+        "file-selector": "^0.6.0",
         "font-awesome": "^4.7.0",
+        "glob": "^8.0.3",
         "lodash.uniqby": "^4.7.0",
-        "mailto-link": "^1.0.0",
+        "mailto-link": "^2.0.0",
         "prop-types": "^15.8.1",
-        "react-bootstrap": "^1.6.4",
+        "react-bootstrap": "^1.6.5",
+        "react-dropzone": "^14.2.1",
         "react-focus-on": "^3.5.4",
+        "react-loading-skeleton": "^3.1.0",
         "react-popper": "^2.2.5",
         "react-proptype-conditional-require": "^1.0.4",
         "react-responsive": "^8.2.0",
         "react-table": "^7.7.0",
         "react-transition-group": "^4.4.2",
-        "tabbable": "^4.0.0",
+        "tabbable": "^5.3.3",
         "uncontrollable": "^7.2.1"
       },
       "peerDependencies": {
         "react": "^16.8.6 || ^17.0.0",
-        "react-dom": "^16.8.6 || ^17.0.0"
+        "react-dom": "^16.8.6 || ^17.0.0",
+        "react-intl": "^5.25.1"
+      }
+    },
+    "node_modules/@edx/paragon/node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz",
+      "integrity": "sha512-Sz07mnQrTekFWLz5BMjOzHl/+NooTdW8F8kDQxjWwbpOJcnoSg4vUDng8d/WR1wOxM0O+CY9Zw0nR054riNYtQ==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@edx/paragon/node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.1.tgz",
+      "integrity": "sha512-HELwwbCz6C1XEcjzyT1Jugmz2NNklMrSPjZOWMlc+ZsHIVk+XOvOXLGGQtFBwSyqfJDNgRq4xBCwWOaZ/d9DEA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.2.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@edx/paragon/node_modules/@fortawesome/react-fontawesome": {
@@ -2451,6 +2484,43 @@
       "peerDependencies": {
         "@fortawesome/fontawesome-svg-core": "~1 || ~6",
         "react": ">=16.x"
+      }
+    },
+    "node_modules/@edx/paragon/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@edx/paragon/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@edx/paragon/node_modules/minimatch": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+      "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@edx/reactifex": {
@@ -4446,6 +4516,7 @@
       "version": "6.4.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4613,11 +4684,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/ansi": {
-      "version": "0.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "dev": true,
@@ -4716,42 +4782,6 @@
       "optional": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "1.1.7",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/isarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/are-we-there-yet/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/arg": {
@@ -4956,7 +4986,8 @@
     },
     "node_modules/assert-ok": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/assert-ok/-/assert-ok-1.0.0.tgz",
+      "integrity": "sha512-lCvYmCpMl8c1tp9ynExhoDEk0gGW43SVVC3RE1VYrrVKhNMy8GHfdiwZdoIM6a605s56bUAbENQxtOC0uZp3wg=="
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
@@ -5001,6 +5032,14 @@
       },
       "engines": {
         "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/attr-accept": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/autoprefixer": {
@@ -6089,11 +6128,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/body-parser": {
       "version": "1.20.0",
       "dev": true,
@@ -6171,12 +6205,19 @@
       "license": "ISC"
     },
     "node_modules/bootstrap": {
-      "version": "4.6.1",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
       "peerDependencies": {
         "jquery": "1.9.1 - 3",
         "popper.js": "^1.16.1"
@@ -6509,25 +6550,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/caporal": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bluebird": "^3.4.7",
-        "cli-table3": "^0.5.0",
-        "colorette": "^1.0.1",
-        "fast-levenshtein": "^2.0.6",
-        "lodash": "^4.17.14",
-        "micromist": "1.1.0",
-        "prettyjson": "^1.2.1",
-        "tabtab": "^2.2.2",
-        "winston": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/capture-exit": {
       "version": "2.0.0",
       "dev": true,
@@ -6541,7 +6563,8 @@
     },
     "node_modules/cast-array": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cast-array/-/cast-array-1.0.1.tgz",
+      "integrity": "sha512-EiqtV+M9L42wd0IRgYjgVGDq7vdNBUUrdecd03QReJp8pIr59o2A1b0XfP+aCUlzLKx2E7zVetaogeJCtiHa+w==",
       "dependencies": {
         "isarray": "0.0.1"
       }
@@ -6808,21 +6831,6 @@
         "webpack": "*"
       }
     },
-    "node_modules/cli-table3": {
-      "version": "0.5.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "optionalDependencies": {
-        "colors": "^1.1.2"
-      }
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "dev": true,
@@ -6890,14 +6898,6 @@
         "node": ">= 0.12.0"
       }
     },
-    "node_modules/code-point-at": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/codecov": {
       "version": "3.8.3",
       "dev": true,
@@ -6958,14 +6958,6 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -7055,47 +7047,6 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
-    },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/concat-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-stream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/concat-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/config-chain": {
       "version": "1.1.13",
@@ -7555,13 +7506,6 @@
         "url": "https://github.com/imagemin/cwebp-bin?sponsor=1"
       }
     },
-    "node_modules/cycle": {
-      "version": "1.0.3",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "dev": true,
@@ -7639,7 +7583,6 @@
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -7953,11 +7896,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -8568,22 +8506,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-check": {
-      "version": "5.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^6.4.1",
-        "caporal": "1.4.0",
-        "glob": "^7.1.2"
-      },
-      "bin": {
-        "es-check": "index.js"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/es-module-lexer": {
       "version": "0.7.1",
@@ -9428,14 +9350,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/exit-hook": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/expand-brackets": {
       "version": "2.1.4",
       "dev": true,
@@ -9772,13 +9686,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eyes": {
-      "version": "0.1.8",
-      "dev": true,
-      "engines": {
-        "node": "> 0.1.90"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
@@ -9912,6 +9819,17 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
+    "node_modules/file-selector": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
+      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/file-type": {
       "version": "12.4.2",
       "dev": true,
@@ -9960,6 +9878,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -10407,18 +10333,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gauge": {
-      "version": "1.2.7",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "ansi": "^0.3.0",
-        "has-unicode": "^2.0.0",
-        "lodash.pad": "^4.1.0",
-        "lodash.padend": "^4.1.0",
-        "lodash.padstart": "^4.1.0"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "dev": true,
@@ -10757,25 +10671,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/has-ansi": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-ansi/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "dev": true,
@@ -10848,11 +10743,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/has-value": {
       "version": "1.0.0",
@@ -12072,14 +11962,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
       "dev": true,
@@ -12460,11 +12342,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -13441,8 +13318,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.6.0",
-      "license": "MIT",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
+      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
       "peer": true
     },
     "node_modules/js-tokens": {
@@ -13778,11 +13656,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.difference": {
-      "version": "4.5.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.escape": {
       "version": "4.0.1",
       "dev": true,
@@ -13832,21 +13705,6 @@
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
-    },
-    "node_modules/lodash.pad": {
-      "version": "4.5.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.padend": {
-      "version": "4.6.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.padstart": {
-      "version": "4.6.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lodash.pick": {
       "version": "4.4.0",
@@ -13916,13 +13774,17 @@
       }
     },
     "node_modules/mailto-link": {
-      "version": "1.0.0",
-      "license": "MIT",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mailto-link/-/mailto-link-2.0.0.tgz",
+      "integrity": "sha512-b5FErkZ4t6mpH1IFZSw7Mm2IQHXQ2R0/5Q4xd7Rv8dVkWvE54mFG/UW7HjfFazXFjXTNsM+dSX2tTeIDrV9K9A==",
       "dependencies": {
         "assert-ok": "~1.0.0",
-        "cast-array": "~1.0.0",
+        "cast-array": "~1.0.1",
         "object-filter": "~1.0.2",
-        "query-string": "~2.4.1"
+        "query-string": "~7.0.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/make-dir": {
@@ -14099,14 +13961,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/micromist": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.camelcase": "^4.3.0"
       }
     },
     "node_modules/mime": {
@@ -14526,16 +14380,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/npmlog": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "ansi": "~0.3.1",
-        "are-we-there-yet": "~1.1.2",
-        "gauge": "~1.2.5"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "dev": true,
@@ -14545,14 +14389,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/nwsapi": {
@@ -14647,7 +14483,8 @@
     },
     "node_modules/object-filter": {
       "version": "1.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
+      "integrity": "sha512-NahvP2vZcy1ZiiYah30CEPw0FpDcSkSePJBMpzl5EQgCmISijiGuJm3SPYp7U+Lf2TljyaIw3E5EgkEx/TNEVA=="
     },
     "node_modules/object-inspect": {
       "version": "1.12.2",
@@ -14888,21 +14725,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/os-shim": {
-      "version": "0.1.3",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ow": {
@@ -15469,7 +15291,9 @@
     },
     "node_modules/popper.js": {
       "version": "1.16.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
       "peer": true,
       "funding": {
         "type": "opencollective",
@@ -16052,18 +15876,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/prettyjson": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "colors": "1.4.0",
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "prettyjson": "bin/prettyjson"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "dev": true,
@@ -16194,13 +16006,28 @@
       }
     },
     "node_modules/query-string": {
-      "version": "2.4.2",
-      "license": "MIT",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
+      "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
       "dependencies": {
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/query-string/node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/querystringify": {
@@ -16448,6 +16275,22 @@
         "react": "^16.14.0"
       }
     },
+    "node_modules/react-dropzone": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
+      "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
+      "dependencies": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.6.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",
       "dev": true,
@@ -16559,6 +16402,14 @@
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "license": "MIT"
+    },
+    "node_modules/react-loading-skeleton": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.1.0.tgz",
+      "integrity": "sha512-j1U1CWWs68nBPOg7tkQqnlFcAMFF6oEK6MgqAo15f8A5p7mjH6xyKn2gHbkcimpwfO0VQXqxAswnSYVr8lWzjw==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/react-overlays": {
       "version": "5.2.0",
@@ -17469,14 +17320,6 @@
         "rtlcss": "bin/rtlcss.js"
       }
     },
-    "node_modules/run-async": {
-      "version": "2.4.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -17498,11 +17341,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/rx": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -18524,16 +18362,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/spawn-sync": {
-      "version": "1.0.15",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "concat-stream": "^1.4.7",
-        "os-shim": "^0.1.2"
-      }
-    },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
       "dev": true,
@@ -18590,6 +18418,14 @@
         "wbuf": "^1.7.3"
       }
     },
+    "node_modules/split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/split-string": {
       "version": "3.1.0",
       "dev": true,
@@ -18618,14 +18454,6 @@
       "version": "0.1.8",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.5",
@@ -18757,7 +18585,9 @@
     },
     "node_modules/strict-uri-encode": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18799,37 +18629,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -19219,216 +19018,9 @@
       "license": "MIT"
     },
     "node_modules/tabbable": {
-      "version": "4.0.0",
-      "license": "MIT"
-    },
-    "node_modules/tabtab": {
-      "version": "2.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^2.2.0",
-        "inquirer": "^1.0.2",
-        "lodash.difference": "^4.5.0",
-        "lodash.uniq": "^4.5.0",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "npmlog": "^2.0.3",
-        "object-assign": "^4.1.0"
-      },
-      "bin": {
-        "tabtab": "bin/tabtab"
-      }
-    },
-    "node_modules/tabtab/node_modules/ansi-escapes": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tabtab/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tabtab/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tabtab/node_modules/chalk": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tabtab/node_modules/cli-cursor": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tabtab/node_modules/cli-width": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/tabtab/node_modules/debug": {
-      "version": "2.6.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/tabtab/node_modules/external-editor": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "extend": "^3.0.0",
-        "spawn-sync": "^1.0.15",
-        "tmp": "^0.0.29"
-      }
-    },
-    "node_modules/tabtab/node_modules/figures": {
-      "version": "1.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tabtab/node_modules/inquirer": {
-      "version": "1.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^1.1.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
-        "cli-width": "^2.0.0",
-        "external-editor": "^1.1.0",
-        "figures": "^1.3.5",
-        "lodash": "^4.3.0",
-        "mute-stream": "0.0.6",
-        "pinkie-promise": "^2.0.0",
-        "run-async": "^2.2.0",
-        "rx": "^4.1.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
-        "through": "^2.3.6"
-      }
-    },
-    "node_modules/tabtab/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tabtab/node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tabtab/node_modules/mute-stream": {
-      "version": "0.0.6",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/tabtab/node_modules/onetime": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tabtab/node_modules/restore-cursor": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tabtab/node_modules/string-width": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tabtab/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tabtab/node_modules/supports-color": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/tabtab/node_modules/tmp": {
-      "version": "0.0.29",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -19993,11 +19585,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -21121,35 +20708,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/winston": {
-      "version": "2.4.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async": "^3.2.3",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "stack-trace": "0.0.x"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/winston/node_modules/async": {
-      "version": "3.2.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/winston/node_modules/colors": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -22729,6 +22287,12 @@
     "@edx/brand": {
       "version": "npm:@edx/brand-openedx@1.1.0"
     },
+    "@edx/browserslist-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.1.1.tgz",
+      "integrity": "sha512-baLX2wxguWNXLIAi26l/iUIJoI9T8LVDH+8+3xP3HjFtWSCOVjz19sgxx4PlWwwMkbUkVmfuxrm2XVueqI6xLw==",
+      "dev": true
+    },
     "@edx/eslint-config": {
       "version": "3.1.0",
       "dev": true,
@@ -22883,35 +22447,82 @@
       }
     },
     "@edx/paragon": {
-      "version": "19.25.3",
+      "version": "20.20.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.20.0.tgz",
+      "integrity": "sha512-spoEuQgRA0pf4Lg3O9a5qjePbf9dWlg206+l5WPNZtDVdBzqoxFdn9vL47GPNJRP4ksHfpTDLdmIkgX7t1TngQ==",
       "requires": {
-        "@fortawesome/fontawesome-svg-core": "^1.2.36",
+        "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
         "@popperjs/core": "^2.11.4",
-        "bootstrap": "^4.6.1",
+        "bootstrap": "^4.6.2",
         "classnames": "^2.3.1",
         "email-prop-type": "^3.0.0",
+        "file-selector": "^0.6.0",
         "font-awesome": "^4.7.0",
+        "glob": "^8.0.3",
         "lodash.uniqby": "^4.7.0",
-        "mailto-link": "^1.0.0",
+        "mailto-link": "^2.0.0",
         "prop-types": "^15.8.1",
-        "react-bootstrap": "^1.6.4",
+        "react-bootstrap": "^1.6.5",
+        "react-dropzone": "^14.2.1",
         "react-focus-on": "^3.5.4",
+        "react-loading-skeleton": "^3.1.0",
         "react-popper": "^2.2.5",
         "react-proptype-conditional-require": "^1.0.4",
         "react-responsive": "^8.2.0",
         "react-table": "^7.7.0",
         "react-transition-group": "^4.4.2",
-        "tabbable": "^4.0.0",
+        "tabbable": "^5.3.3",
         "uncontrollable": "^7.2.1"
       },
       "dependencies": {
+        "@fortawesome/fontawesome-common-types": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz",
+          "integrity": "sha512-Sz07mnQrTekFWLz5BMjOzHl/+NooTdW8F8kDQxjWwbpOJcnoSg4vUDng8d/WR1wOxM0O+CY9Zw0nR054riNYtQ=="
+        },
+        "@fortawesome/fontawesome-svg-core": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.1.tgz",
+          "integrity": "sha512-HELwwbCz6C1XEcjzyT1Jugmz2NNklMrSPjZOWMlc+ZsHIVk+XOvOXLGGQtFBwSyqfJDNgRq4xBCwWOaZ/d9DEA==",
+          "requires": {
+            "@fortawesome/fontawesome-common-types": "6.2.1"
+          }
+        },
         "@fortawesome/react-fontawesome": {
           "version": "0.1.19",
           "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.19.tgz",
           "integrity": "sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==",
           "requires": {
             "prop-types": "^15.8.1"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+          "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
           }
         }
       }
@@ -24377,7 +23988,8 @@
     },
     "acorn": {
       "version": "6.4.2",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -24482,10 +24094,6 @@
       "dev": true,
       "requires": {}
     },
-    "ansi": {
-      "version": "0.3.1",
-      "dev": true
-    },
     "ansi-escapes": {
       "version": "4.3.2",
       "dev": true,
@@ -24533,40 +24141,6 @@
           "version": "4.4.0",
           "dev": true,
           "optional": true
-        }
-      }
-    },
-    "are-we-there-yet": {
-      "version": "1.1.7",
-      "dev": true,
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
         }
       }
     },
@@ -24698,7 +24272,9 @@
       "dev": true
     },
     "assert-ok": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-ok/-/assert-ok-1.0.0.tgz",
+      "integrity": "sha512-lCvYmCpMl8c1tp9ynExhoDEk0gGW43SVVC3RE1VYrrVKhNMy8GHfdiwZdoIM6a605s56bUAbENQxtOC0uZp3wg=="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -24726,6 +24302,11 @@
     "atob": {
       "version": "2.1.2",
       "dev": true
+    },
+    "attr-accept": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
     },
     "autoprefixer": {
       "version": "10.2.6",
@@ -25494,10 +25075,6 @@
         }
       }
     },
-    "bluebird": {
-      "version": "3.7.2",
-      "dev": true
-    },
     "body-parser": {
       "version": "1.20.0",
       "dev": true,
@@ -25557,7 +25134,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.1",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
       "requires": {}
     },
     "brace-expansion": {
@@ -25770,21 +25349,6 @@
       "version": "1.0.30001382",
       "dev": true
     },
-    "caporal": {
-      "version": "1.4.0",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.4.7",
-        "cli-table3": "^0.5.0",
-        "colorette": "^1.0.1",
-        "fast-levenshtein": "^2.0.6",
-        "lodash": "^4.17.14",
-        "micromist": "1.1.0",
-        "prettyjson": "^1.2.1",
-        "tabtab": "^2.2.2",
-        "winston": "^2.3.1"
-      }
-    },
     "capture-exit": {
       "version": "2.0.0",
       "dev": true,
@@ -25794,6 +25358,8 @@
     },
     "cast-array": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cast-array/-/cast-array-1.0.1.tgz",
+      "integrity": "sha512-EiqtV+M9L42wd0IRgYjgVGDq7vdNBUUrdecd03QReJp8pIr59o2A1b0XfP+aCUlzLKx2E7zVetaogeJCtiHa+w==",
       "requires": {
         "isarray": "0.0.1"
       }
@@ -25969,15 +25535,6 @@
         "del": "^4.1.1"
       }
     },
-    "cli-table3": {
-      "version": "0.5.1",
-      "dev": true,
-      "requires": {
-        "colors": "^1.1.2",
-        "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
-      }
-    },
     "cliui": {
       "version": "7.0.4",
       "dev": true,
@@ -26027,10 +25584,6 @@
       "version": "4.6.0",
       "dev": true
     },
-    "code-point-at": {
-      "version": "1.1.0",
-      "dev": true
-    },
     "codecov": {
       "version": "3.8.3",
       "dev": true,
@@ -26070,10 +25623,6 @@
       "dev": true
     },
     "colorette": {
-      "version": "1.4.0",
-      "dev": true
-    },
-    "colors": {
       "version": "1.4.0",
       "dev": true
     },
@@ -26145,42 +25694,6 @@
     },
     "concat-map": {
       "version": "0.0.1"
-    },
-    "concat-stream": {
-      "version": "1.6.2",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
     },
     "config-chain": {
       "version": "1.1.13",
@@ -26466,10 +25979,6 @@
         "bin-wrapper": "^4.0.1"
       }
     },
-    "cycle": {
-      "version": "1.0.3",
-      "dev": true
-    },
     "damerau-levenshtein": {
       "version": "1.0.8",
       "dev": true
@@ -26517,8 +26026,7 @@
       "dev": true
     },
     "decode-uri-component": {
-      "version": "0.2.0",
-      "dev": true
+      "version": "0.2.0"
     },
     "decompress": {
       "version": "4.2.1",
@@ -26729,10 +26237,6 @@
       }
     },
     "delayed-stream": {
-      "version": "1.0.0",
-      "dev": true
-    },
-    "delegates": {
       "version": "1.0.0",
       "dev": true
     },
@@ -27156,15 +26660,6 @@
     "es-array-method-boxes-properly": {
       "version": "1.0.0",
       "dev": true
-    },
-    "es-check": {
-      "version": "5.2.4",
-      "dev": true,
-      "requires": {
-        "acorn": "^6.4.1",
-        "caporal": "1.4.0",
-        "glob": "^7.1.2"
-      }
     },
     "es-module-lexer": {
       "version": "0.7.1",
@@ -27718,10 +27213,6 @@
       "version": "0.1.2",
       "dev": true
     },
-    "exit-hook": {
-      "version": "1.1.1",
-      "dev": true
-    },
     "expand-brackets": {
       "version": "2.1.4",
       "dev": true,
@@ -27959,10 +27450,6 @@
         }
       }
     },
-    "eyes": {
-      "version": "0.1.8",
-      "dev": true
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "dev": true
@@ -28055,6 +27542,14 @@
         "schema-utils": "^3.0.0"
       }
     },
+    "file-selector": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
+      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
     "file-type": {
       "version": "12.4.2",
       "dev": true
@@ -28084,6 +27579,11 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
     },
     "finalhandler": {
       "version": "1.2.0",
@@ -28366,17 +27866,6 @@
       "version": "1.2.3",
       "dev": true
     },
-    "gauge": {
-      "version": "1.2.7",
-      "dev": true,
-      "requires": {
-        "ansi": "^0.3.0",
-        "has-unicode": "^2.0.0",
-        "lodash.pad": "^4.1.0",
-        "lodash.padend": "^4.1.0",
-        "lodash.padstart": "^4.1.0"
-      }
-    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "dev": true
@@ -28590,19 +28079,6 @@
         "function-bind": "^1.1.1"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "dev": true
-        }
-      }
-    },
     "has-bigints": {
       "version": "1.0.2",
       "dev": true
@@ -28641,10 +28117,6 @@
       "requires": {
         "has-symbols": "^1.0.2"
       }
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -29448,10 +28920,6 @@
       "version": "2.1.1",
       "dev": true
     },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "dev": true
-    },
     "is-generator-fn": {
       "version": "2.1.0",
       "dev": true
@@ -29677,10 +29145,6 @@
     },
     "isobject": {
       "version": "3.0.1",
-      "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -30371,7 +29835,9 @@
       }
     },
     "jquery": {
-      "version": "3.6.0",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
+      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
       "peer": true
     },
     "js-tokens": {
@@ -30596,10 +30062,6 @@
       "version": "4.0.8",
       "dev": true
     },
-    "lodash.difference": {
-      "version": "4.5.0",
-      "dev": true
-    },
     "lodash.escape": {
       "version": "4.0.1",
       "dev": true
@@ -30641,18 +30103,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-      "dev": true
-    },
-    "lodash.pad": {
-      "version": "4.5.1",
-      "dev": true
-    },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "dev": true
-    },
-    "lodash.padstart": {
-      "version": "4.6.1",
       "dev": true
     },
     "lodash.pick": {
@@ -30706,12 +30156,14 @@
       }
     },
     "mailto-link": {
-      "version": "1.0.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mailto-link/-/mailto-link-2.0.0.tgz",
+      "integrity": "sha512-b5FErkZ4t6mpH1IFZSw7Mm2IQHXQ2R0/5Q4xd7Rv8dVkWvE54mFG/UW7HjfFazXFjXTNsM+dSX2tTeIDrV9K9A==",
       "requires": {
         "assert-ok": "~1.0.0",
-        "cast-array": "~1.0.0",
+        "cast-array": "~1.0.1",
         "object-filter": "~1.0.2",
-        "query-string": "~2.4.1"
+        "query-string": "~7.0.0"
       }
     },
     "make-dir": {
@@ -30828,13 +30280,6 @@
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
-      }
-    },
-    "micromist": {
-      "version": "1.1.0",
-      "dev": true,
-      "requires": {
-        "lodash.camelcase": "^4.3.0"
       }
     },
     "mime": {
@@ -31101,25 +30546,12 @@
         "path-key": "^3.0.0"
       }
     },
-    "npmlog": {
-      "version": "2.0.4",
-      "dev": true,
-      "requires": {
-        "ansi": "~0.3.1",
-        "are-we-there-yet": "~1.1.2",
-        "gauge": "~1.2.5"
-      }
-    },
     "nth-check": {
       "version": "2.1.1",
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0"
       }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "dev": true
     },
     "nwsapi": {
       "version": "2.2.1",
@@ -31183,7 +30615,9 @@
       }
     },
     "object-filter": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
+      "integrity": "sha512-NahvP2vZcy1ZiiYah30CEPw0FpDcSkSePJBMpzl5EQgCmISijiGuJm3SPYp7U+Lf2TljyaIw3E5EgkEx/TNEVA=="
     },
     "object-inspect": {
       "version": "1.12.2",
@@ -31329,14 +30763,6 @@
       "requires": {
         "arch": "^2.1.0"
       }
-    },
-    "os-shim": {
-      "version": "0.1.3",
-      "dev": true
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "dev": true
     },
     "ow": {
       "version": "0.17.0",
@@ -31678,6 +31104,8 @@
     },
     "popper.js": {
       "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
       "peer": true
     },
     "portfinder": {
@@ -31997,14 +31425,6 @@
         }
       }
     },
-    "prettyjson": {
-      "version": "1.2.5",
-      "dev": true,
-      "requires": {
-        "colors": "1.4.0",
-        "minimist": "^1.2.0"
-      }
-    },
     "process-nextick-args": {
       "version": "2.0.1",
       "dev": true
@@ -32098,9 +31518,21 @@
       }
     },
     "query-string": {
-      "version": "2.4.2",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
+      "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
       "requires": {
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "dependencies": {
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
+        }
       }
     },
     "querystringify": {
@@ -32266,6 +31698,16 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-dropzone": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
+      "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
+      "requires": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.6.0",
+        "prop-types": "^15.8.1"
+      }
+    },
     "react-error-overlay": {
       "version": "6.0.11",
       "dev": true
@@ -32340,6 +31782,12 @@
     },
     "react-lifecycles-compat": {
       "version": "3.0.4"
+    },
+    "react-loading-skeleton": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.1.0.tgz",
+      "integrity": "sha512-j1U1CWWs68nBPOg7tkQqnlFcAMFF6oEK6MgqAo15f8A5p7mjH6xyKn2gHbkcimpwfO0VQXqxAswnSYVr8lWzjw==",
+      "requires": {}
     },
     "react-overlays": {
       "version": "5.2.0",
@@ -32936,20 +32384,12 @@
         "strip-json-comments": "^3.1.1"
       }
     },
-    "run-async": {
-      "version": "2.4.1",
-      "dev": true
-    },
     "run-parallel": {
       "version": "1.2.0",
       "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "rx": {
-      "version": "4.1.0",
-      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -33666,14 +33106,6 @@
       "version": "0.4.1",
       "dev": true
     },
-    "spawn-sync": {
-      "version": "1.0.15",
-      "dev": true,
-      "requires": {
-        "concat-stream": "^1.4.7",
-        "os-shim": "^0.1.2"
-      }
-    },
     "spdx-correct": {
       "version": "3.1.1",
       "dev": true,
@@ -33721,6 +33153,11 @@
         "wbuf": "^1.7.3"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "dev": true,
@@ -33741,10 +33178,6 @@
     },
     "stable": {
       "version": "0.1.8",
-      "dev": true
-    },
-    "stack-trace": {
-      "version": "0.0.10",
       "dev": true
     },
     "stack-utils": {
@@ -33838,7 +33271,9 @@
       }
     },
     "strict-uri-encode": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dev": true,
+      "optional": true
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -33859,27 +33294,6 @@
       "requires": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
-      }
-    },
-    "string-width": {
-      "version": "2.1.1",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.1",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "string.prototype.matchall": {
@@ -34139,155 +33553,9 @@
       "dev": true
     },
     "tabbable": {
-      "version": "4.0.0"
-    },
-    "tabtab": {
-      "version": "2.2.2",
-      "dev": true,
-      "requires": {
-        "debug": "^2.2.0",
-        "inquirer": "^1.0.2",
-        "lodash.difference": "^4.5.0",
-        "lodash.uniq": "^4.5.0",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "npmlog": "^2.0.3",
-        "object-assign": "^4.1.0"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^1.0.1"
-          }
-        },
-        "cli-width": {
-          "version": "2.2.1",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "external-editor": {
-          "version": "1.1.1",
-          "dev": true,
-          "requires": {
-            "extend": "^3.0.0",
-            "spawn-sync": "^1.0.15",
-            "tmp": "^0.0.29"
-          }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
-          }
-        },
-        "inquirer": {
-          "version": "1.2.3",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^1.1.0",
-            "chalk": "^1.0.0",
-            "cli-cursor": "^1.0.1",
-            "cli-width": "^2.0.0",
-            "external-editor": "^1.1.0",
-            "figures": "^1.3.5",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.6",
-            "pinkie-promise": "^2.0.0",
-            "run-async": "^2.2.0",
-            "rx": "^4.1.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "dev": true
-        },
-        "mute-stream": {
-          "version": "0.0.6",
-          "dev": true
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "dev": true,
-          "requires": {
-            "exit-hook": "^1.0.0",
-            "onetime": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "dev": true
-        },
-        "tmp": {
-          "version": "0.0.29",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
-        }
-      }
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
     },
     "tapable": {
       "version": "2.2.1",
@@ -34654,10 +33922,6 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "dev": true
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -35355,28 +34619,6 @@
     "wildcard": {
       "version": "2.0.0",
       "dev": true
-    },
-    "winston": {
-      "version": "2.4.6",
-      "dev": true,
-      "requires": {
-        "async": "^3.2.3",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "stack-trace": "0.0.x"
-      },
-      "dependencies": {
-        "async": {
-          "version": "3.2.4",
-          "dev": true
-        },
-        "colors": {
-          "version": "1.0.3",
-          "dev": true
-        }
-      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "build": "fedx-scripts webpack",
     "i18n_extract": "BABEL_ENV=i18n fedx-scripts babel src --quiet > /dev/null",
-    "is-es5": "es-check es5 ./dist/*.js",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
@@ -25,15 +24,14 @@
     "access": "public"
   },
   "browserslist": [
-    "last 2 versions",
-    "ie 11"
+    "extends @edx/browserslist-config"
   ],
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "11.5.2",
     "@edx/frontend-component-header": "3.5.0",
     "@edx/frontend-platform": "2.6.2",
-    "@edx/paragon": "19.25.3",
+    "@edx/paragon": "^20.20.0",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@fortawesome/free-brands-svg-icons": "5.15.4",
     "@fortawesome/free-regular-svg-icons": "5.15.4",
@@ -48,10 +46,10 @@
     "prop-types": "15.8.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
+    "react-helmet": "6.1.0",
     "react-redux": "7.2.9",
     "react-router": "5.3.4",
     "react-router-dom": "5.3.4",
-    "react-helmet": "6.1.0",
     "redux": "4.2.0",
     "redux-devtools-extension": "2.13.9",
     "redux-logger": "3.0.6",
@@ -64,12 +62,12 @@
   "devDependencies": {
     "@commitlint/cli": "17.3.0",
     "@commitlint/config-angular": "17.3.0",
-    "@edx/reactifex": "2.1.1",
+    "@edx/browserslist-config": "^1.1.1",
     "@edx/frontend-build": "12.0.6",
+    "@edx/reactifex": "2.1.1",
     "codecov": "3.8.3",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.7",
-    "es-check": "5.2.4",
     "glob": "7.2.3",
     "react-test-renderer": "16.14.0",
     "reactifex": "1.1.1",

--- a/src/profile/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/profile/__snapshots__/ProfilePage.test.jsx.snap
@@ -60,7 +60,7 @@ exports[`<ProfilePage /> Renders correctly in various states test country edit w
                 className="profile-avatar-menu-container"
               >
                 <div
-                  className="dropdown"
+                  className="pgn__dropdown pgn__dropdown-light dropdown"
                   data-testid="dropdown"
                 >
                   <button
@@ -2441,7 +2441,7 @@ exports[`<ProfilePage /> Renders correctly in various states test education edit
                 className="profile-avatar-menu-container"
               >
                 <div
-                  className="dropdown"
+                  className="pgn__dropdown pgn__dropdown-light dropdown"
                   data-testid="dropdown"
                 >
                   <button
@@ -3616,7 +3616,7 @@ exports[`<ProfilePage /> Renders correctly in various states test preferreded la
                 className="profile-avatar-menu-container"
               >
                 <div
-                  className="dropdown"
+                  className="pgn__dropdown pgn__dropdown-light dropdown"
                   data-testid="dropdown"
                 >
                   <button
@@ -5898,7 +5898,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
                 className="profile-avatar-menu-container"
               >
                 <div
-                  className="dropdown"
+                  className="pgn__dropdown pgn__dropdown-light dropdown"
                   data-testid="dropdown"
                 >
                   <button
@@ -6948,7 +6948,7 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
                 className="profile-avatar-menu-container"
               >
                 <div
-                  className="dropdown"
+                  className="pgn__dropdown pgn__dropdown-light dropdown"
                   data-testid="dropdown"
                 >
                   <button
@@ -8065,7 +8065,7 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
                 className="profile-avatar-menu-container"
               >
                 <div
-                  className="dropdown"
+                  className="pgn__dropdown pgn__dropdown-light dropdown"
                   data-testid="dropdown"
                 >
                   <button
@@ -9188,7 +9188,7 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
                 className="profile-avatar-menu-container"
               >
                 <div
-                  className="dropdown"
+                  className="pgn__dropdown pgn__dropdown-light dropdown"
                   data-testid="dropdown"
                 >
                   <button


### PR DESCRIPTION
* Removes custom `browserslist` configuration in favor of using a [shared configuration](https://github.com/edx/browserslist-config).
* Removes `is-es5` check in CI since ES5 was only needed for IE 11 support which is dropped. The supported browsers defined by the shared configuration all [natively support ES6](https://caniuse.com/?search=es6).

This change reduces the resultant asset bundle size.
* Update `edx/paragon` version