### PR TITLE
fix: error when trying to save 'other education'

### DIFF
--- a/src/profile/data/constants.js
+++ b/src/profile/data/constants.js
@@ -7,7 +7,7 @@ const EDUCATION_LEVELS = [
   'jhs',
   'el',
   'none',
-  'o',
+  'other',
 ];
 
 const SOCIAL = {


### PR DESCRIPTION
When user selects "Other Education" and clicks save - error occurs.

It's caused by the wrong API call payload value `'o'`
Fix: use the `'other'` payload value instead (the valid one).

Related PRs:
- [Olive](https://github.com/openedx/frontend-app-profile/pull/666)
- [master](https://github.com/openedx/frontend-app-profile/pull/667)