### PR TITLE
build: display learning goal in profile

### DIFF
--- a/src/profile/__mocks__/viewOwnProfile.mockStore.js
+++ b/src/profile/__mocks__/viewOwnProfile.mockStore.js
@@ -42,7 +42,8 @@ module.exports = {
     secondaryEmail: null,
     timeZone: null,
     gender: null,
-    accountPrivacy: 'custom'
+    accountPrivacy: 'custom',
+    learningGoal: 'I want to advance my career'
   },
   profilePage: {
     errors: {},
@@ -91,7 +92,8 @@ module.exports = {
       timeZone: null,
       levelOfEducation: 'el',
       gender: null,
-      accountPrivacy: 'custom'
+      accountPrivacy: 'custom',
+      learningGoal: 'I want to advance my career'
     },
     preferences: {
       visibilityUserLocation: 'all_users',

--- a/src/profile/forms/LearningGoal.jsx
+++ b/src/profile/forms/LearningGoal.jsx
@@ -1,0 +1,5 @@
+const LearningGoal = () => {
+  return null;
+};
+
+export default LearningGoal;

--- a/src/profile/forms/LearningGoal.test.jsx
+++ b/src/profile/forms/LearningGoal.test.jsx
@@ -27,7 +27,7 @@ const storeMocks = {
 // props to be passed down to LearningGoal component
 const requiredLearningGoalProps = {
   formId: 'learningGoal',
-  learningGoal: "I want to advance my career.",
+  learningGoal: "I want to advance my career",
   drafts: {},
   visibilityLearningGoal: 'private',
   editMode: 'static',
@@ -115,16 +115,8 @@ describe('<LearningGoal />', () => {
     const wrapper = mount(component);
     const learningGoal = wrapper.find(LearningGoal);
 
-    it('using "Update My Learning Goal" button', () => {
-      learningGoal.find('Update button').simulate('click');
-      expect(openHandler).toHaveBeenCalledTimes(1);
-      //expect Skills Builder FullscreenModal's isOpen to be true
-    });
-      
-    it('using "Edit" button', () => {
-      learningGoal.find('Edit button').simulate('click');
-      expect(openHandler).toHaveBeenCalledTimes(1);
-      //expect Skills Builder FullscreenModal's isOpen to be true
+    it('renders the current learning goal', () => {
+      expect(learningGoal).toContain('I want to advance my career');
     });
   });
 });

--- a/src/profile/forms/LearningGoal.test.jsx
+++ b/src/profile/forms/LearningGoal.test.jsx
@@ -1,0 +1,130 @@
+import { mount } from 'enzyme';
+import PropTypes from 'prop-types';
+import React, { useMemo } from 'react';
+import { Provider } from 'react-redux';
+import renderer from 'react-test-renderer';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { configure as configureI18n, IntlProvider } from '@edx/frontend-platform/i18n';
+import { getConfig } from '@edx/frontend-platform';
+import { AppContext } from '@edx/frontend-platform/react';
+import messages from '../../i18n';
+
+import viewOwnProfileMockStore from '../__mocks__/viewOwnProfile.mockStore';
+import viewOtherProfileMockStore from '../__mocks__/viewOtherProfile.mockStore';
+import savingEditedBioMockStore from '../__mocks__/savingEditedBio.mockStore';
+
+import LearningGoal from './LearningGoal';
+import SkillsBuilder from '../../skills/SkillsBuilder';
+
+const mockStore = configureMockStore([thunk]);
+const storeMocks = {
+  viewOwnProfile: viewOwnProfileMockStore,
+  viewOtherProfile: viewOtherProfileMockStore,
+  savingEditedBio: savingEditedBioMockStore,
+};
+
+// props to be passed down to LearningGoal component
+const requiredLearningGoalProps = {
+  formId: 'learningGoal',
+  learningGoal: "I want to advance my career.",
+  drafts: {},
+  visibilityLearningGoal: 'private',
+  editMode: 'static',
+  saveState: null,
+  error: null,
+  openHandler: jest.fn(),
+};
+
+configureI18n({
+  loggingService: { logError: jest.fn() },
+  config: {
+    ENVIRONMENT: 'production',
+    LANGUAGE_PREFERENCE_COOKIE_NAME: 'yum',
+  },
+  messages,
+});
+
+beforeEach(() => {
+
+});
+
+const LearningGoalWrapper = (props) => {
+  const contextValue = useMemo(() => ({
+    authenticatedUser: { userId: null, username: null, administrator: false },
+    config: getConfig(),
+  }), []);
+  return (
+    <AppContext.Provider
+      value={contextValue}
+    >
+      <IntlProvider locale="en">
+        <Provider store={props.store}>
+          <LearningGoal {...props} />
+        </Provider>
+      </IntlProvider>
+    </AppContext.Provider>
+  );
+};
+
+LearningGoalWrapper.defaultProps = {
+  store: mockStore(viewOwnProfileMockStore),
+};
+
+LearningGoalWrapper.propTypes = {
+  store: PropTypes.shape({}),
+};
+
+// in the case of an error occurring while saving new Learning Goal
+const LearningGoalWrapperWithStore = ({ store }) => {
+  const contextValue = useMemo(() => ({
+    authenticatedUser: { userId: null, username: null, administrator: false },
+    config: getConfig(),
+  }), []);
+  return (
+    <AppContext.Provider
+      value={contextValue}
+    >
+      <IntlProvider locale="en">
+        <Provider store={mockStore(store)}>
+          <LearningGoal {...defaultProps} />
+        </Provider>
+      </IntlProvider>
+    </AppContext.Provider>
+  );
+};
+
+LearningGoalWrapperWithStore.defaultProps = {
+  store: mockStore(savingEditedBioMockStore),
+};
+
+LearningGoalWrapperWithStore.propTypes = {
+  store: PropTypes.shape({}),
+};
+
+describe('<LearningGoal />', () => {
+  describe('Opens Skills Builder modal', () => {
+    const openHandler = jest.fn();
+    const component = (
+      <LearningGoal 
+      {...requiredLearningGoalProps}
+      formId="learningGoal"
+      openHandler={openHandler}
+      />
+    );
+    const wrapper = mount(component);
+    const learningGoal = wrapper.find(LearningGoal);
+
+    it('using "Update My Learning Goal" button', () => {
+      learningGoal.find('Update button').simulate('click');
+      expect(openHandler).toHaveBeenCalledTimes(1);
+      //expect Skills Builder FullscreenModal's isOpen to be true
+    });
+      
+    it('using "Edit" button', () => {
+      learningGoal.find('Edit button').simulate('click');
+      expect(openHandler).toHaveBeenCalledTimes(1);
+      //expect Skills Builder FullscreenModal's isOpen to be true
+    });
+  });
+});


### PR DESCRIPTION
### What ###
Add a Learning Goal component to Profile that displays user's current Learning Goal. 

* This PR includes a unit test that checks for a rendered Learning Goal component with mock data provided.
* The component is feature flagged and not set to be released to users until after the Skills Builder form has been finished. 
* Mock data is currently used, the integration with the back-end is for another story. 

#### Associated Jira links ####
https://2u-internal.atlassian.net/browse/APER-2244
https://2u-internal.atlassian.net/browse/APER-2181

![Screenshot 2023-02-07 at 10 18 19 AM](https://user-images.githubusercontent.com/62807795/217331673-8f3f9df2-0980-4300-a4b2-2dc000517eb4.png)