### PR TITLE
fix: adding configure component to filter jobs

### DIFF
--- a/src/skills-builder/skills-builder-modal/select-preferences/CareerInterestSelect.jsx
+++ b/src/skills-builder/skills-builder-modal/select-preferences/CareerInterestSelect.jsx
@@ -5,7 +5,7 @@ import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import {
   Stack, Row, Col, Form,
 } from '@edx/paragon';
-import { InstantSearch } from 'react-instantsearch-hooks-web';
+import { Configure, InstantSearch } from 'react-instantsearch-hooks-web';
 import JobTitleInstantSearch from './JobTitleInstantSearch';
 import CareerInterestCard from './CareerInterestCard';
 import { addCareerInterest } from '../../data/actions';
@@ -42,6 +42,7 @@ const CareerInterestSelect = () => {
           {formatMessage(messages.careerInterestPrompt)}
         </h4>
         <InstantSearch searchClient={searchClient} indexName={getConfig().ALGOLIA_JOBS_INDEX_NAME}>
+          <Configure filters="b2c_opt_in:true" />
           <JobTitleInstantSearch
             onSelected={handleCareerInterestSelect}
             placeholder={formatMessage(messages.careerInterestInputPlaceholderText)}

--- a/src/skills-builder/skills-builder-modal/select-preferences/JobTitleSelect.jsx
+++ b/src/skills-builder/skills-builder-modal/select-preferences/JobTitleSelect.jsx
@@ -5,7 +5,7 @@ import {
 } from '@edx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { InstantSearch } from 'react-instantsearch-hooks-web';
+import { Configure, InstantSearch } from 'react-instantsearch-hooks-web';
 import { setCurrentJobTitle } from '../../data/actions';
 import { SkillsBuilderContext } from '../../skills-builder-context';
 import JobTitleInstantSearch from './JobTitleInstantSearch';
@@ -52,6 +52,7 @@ const JobTitleSelect = () => {
           {formatMessage(messages.jobTitlePrompt)}
         </h4>
         <InstantSearch searchClient={searchClient} indexName={getConfig().ALGOLIA_JOBS_INDEX_NAME}>
+          <Configure filters="b2c_opt_in:true" />
           <JobTitleInstantSearch
             onSelected={handleCurrentJobTitleSelect}
             placeholder={formatMessage(messages.jobTitleInputPlaceholderText)}

--- a/src/skills-builder/test/setupSkillsBuilder.jsx
+++ b/src/skills-builder/test/setupSkillsBuilder.jsx
@@ -11,6 +11,7 @@ jest.mock('@edx/frontend-platform/logging');
 jest.mock('react-instantsearch-hooks-web', () => ({
   // eslint-disable-next-line react/prop-types
   InstantSearch: ({ children }) => (<div>{children}</div>),
+  Configure: jest.fn(() => (null)),
   useSearchBox: jest.fn(() => ({ refine: jest.fn() })),
   useHits: jest.fn(() => ({ hits: mockData.hits })),
 }));


### PR DESCRIPTION
This PR adds filtering for the job titles we receive from Algolia. This is done using the `Configure` component supplied by the `react-instantsearch-hooks-web` package.

[Documentation on `Configure`](https://www.algolia.com/doc/api-reference/widgets/configure/react-hooks/)

The filter had to be added to Algolia as well:

![Screenshot 2023-05-10 at 4 16 04 PM](https://github.com/openedx/frontend-app-profile/assets/92897870/3efea4eb-45a8-4298-b1be-880b478940b6)

### JIRA
[APER-2405](https://2u-internal.atlassian.net/browse/APER-2405)

