### PR TITLE
fix: remove filtering from current job select

### DIFF
--- a/src/skills-builder/skills-builder-modal/select-preferences/JobTitleSelect.jsx
+++ b/src/skills-builder/skills-builder-modal/select-preferences/JobTitleSelect.jsx
@@ -5,7 +5,7 @@ import {
 } from '@edx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { Configure, InstantSearch } from 'react-instantsearch-hooks-web';
+import { InstantSearch } from 'react-instantsearch-hooks-web';
 import { setCurrentJobTitle } from '../../data/actions';
 import { SkillsBuilderContext } from '../../skills-builder-context';
 import JobTitleInstantSearch from './JobTitleInstantSearch';
@@ -52,7 +52,6 @@ const JobTitleSelect = () => {
           {formatMessage(messages.jobTitlePrompt)}
         </h4>
         <InstantSearch searchClient={searchClient} indexName={getConfig().ALGOLIA_JOBS_INDEX_NAME}>
-          <Configure filters="b2c_opt_in:true" />
           <JobTitleInstantSearch
             onSelected={handleCurrentJobTitleSelect}
             placeholder={formatMessage(messages.jobTitleInputPlaceholderText)}


### PR DESCRIPTION
Filtering was added for current job selection when we actually do not want to filter this list of jobs. We only need to filter the jobs that we intend to give recommendations for. This PR removes filtering for the `JobTitleSelect` component.