### PR TITLE
fix: error when trying to save 'other education'

### DIFF
--- a/src/profile/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/profile/__snapshots__/ProfilePage.test.jsx.snap
@@ -2995,7 +2995,7 @@ exports[`<ProfilePage /> Renders correctly in various states test education edit
                       No formal education
                     </option>
                     <option
-                      value="o"
+                      value="other"
                     >
                       Other education
                     </option>

--- a/src/profile/data/constants.js
+++ b/src/profile/data/constants.js
@@ -7,7 +7,7 @@ const EDUCATION_LEVELS = [
   'jhs',
   'el',
   'none',
-  'o',
+  'other',
 ];
 
 const SOCIAL = {


### PR DESCRIPTION
this is a backport of https://github.com/openedx/frontend-app-profile/pull/667

When a user selects "Other Education" and clicks save - an error occurs.

It's caused by the wrong API call payload value `'o'` Fix: use the `'other'` payload value instead (the valid one).