### PR TITLE
fix: disable 'select a goal' from goal dropdown when a goal has been selected

### DIFF
--- a/src/skills-builder/skills-builder-modal/select-preferences/GoalSelect.jsx
+++ b/src/skills-builder/skills-builder-modal/select-preferences/GoalSelect.jsx
@@ -42,7 +42,7 @@ const GoalDropdown = () => {
         onChange={handleGoalSelect}
         data-testid="goal-select-dropdown"
       >
-        <option value="">{formatMessage(messages.selectLearningGoal)}</option>
+        <option value="" disabled={currentGoal}>{formatMessage(messages.selectLearningGoal)}</option>
         <option>{formatMessage(messages.learningGoalStartCareer)}</option>
         <option>{formatMessage(messages.learningGoalAdvanceCareer)}</option>
         <option>{formatMessage(messages.learningGoalChangeCareer)}</option>

--- a/src/skills-builder/skills-builder-modal/select-preferences/SelectPreferences.jsx
+++ b/src/skills-builder/skills-builder-modal/select-preferences/SelectPreferences.jsx
@@ -27,7 +27,7 @@ const SelectPreferences = () => {
           <JobTitleSelect />
         )}
 
-        {currentJobTitle && (
+        {currentGoal && currentJobTitle && (
           <CareerInterestSelect />
         )}
       </Stack>


### PR DESCRIPTION
# Context

[APER-2337 -- Skills Builder's third prompt remains when currentGoal is reset to "Select a goal"](https://2u-internal.atlassian.net/browse/APER-2337) 

When filling out the Skills Builder form, the second and third parts of the form would appear once the learner selected a goal. A bug existed where the learner could answer all three parts of the form, "unselect" their goal by selecting "Select a goal", and only the second portion of the form would disappear -- not the third.

# Goal

Prevent users from selecting "Select a goal" once a goal has been selected. They're now only able to switch among the acceptable goal options. For additional precaution, the third portion of the form will be hidden if the `currentGoal` is falsy.

## Before fix
<img width="1005" alt="Screenshot 2023-04-04 at 9 36 30 AM" src="https://github.com/openedx/frontend-app-profile/assets/62807795/2d7eb3f1-88eb-4d02-8a43-cfa0d5993338">

## After fix
![Screenshot 2023-05-22 at 12 51 58 PM](https://github.com/openedx/frontend-app-profile/assets/62807795/4267e001-05ef-4949-ac51-3da8f56962a5)
