### PR TITLE
fix: fallback src typo for course cards

### DIFF
--- a/src/skills-builder/skills-builder-modal/view-results/RecommendationCard.jsx
+++ b/src/skills-builder/skills-builder-modal/view-results/RecommendationCard.jsx
@@ -24,8 +24,8 @@ const RecommendationCard = ({ rec, productType, handleCourseCardClick }) => {
         <Card.ImageCap
           src={cardImageUrl}
           logoSrc={logoImageUrl}
-          fallackSrc={cardImageCapFallbackSrc}
-          fallBackLogo={cardImageCapFallbackSrc}
+          fallbackSrc={cardImageCapFallbackSrc}
+          fallbackLogoSrc={cardImageCapFallbackSrc}
         />
         <Card.Header title={title} />
         <Card.Section>


### PR DESCRIPTION
There was a typo in the attributes for the `RecommendationCard` component causing there to be no fallback image. This was making the course cards look awkward while waiting for the images to load.