### PR TITLE
fix: switch out class overwrite in SCSS for an aria-label selector

### DIFF
--- a/src/skills-builder/skills-builder-modal/skillsBuilderModal.scss
+++ b/src/skills-builder/skills-builder-modal/skillsBuilderModal.scss
@@ -1,16 +1,14 @@
-.skills-builder-modal {
-  button[aria-label="Close"][type="button"]{
-    color: $white;
-  }
+button[aria-label="Close"][type="button"]{
+  color: $white;
 }
-
 
 $breakpoint-medium: 992px;
 @media (max-width: $breakpoint-medium) {
   .med-min-height {
     min-height: map-get($spacers, 6);
   }
-  .pgn__modal-close-container {
-    top: 1rem;
+  button[aria-label="Close"][type="button"]{
+    position: relative;
+    top: 0.5rem;
   }
 }


### PR DESCRIPTION
# Context: 

In [APER-2341](https://github.com/openedx/frontend-app-profile/pull/756) I originally overwrote a class's CSS styling, which is not considered best practice as the class (`pgn__modal-close-container`) could be renamed at any point and the overwrite would create a breaking change. 

This PR replaces that implementation by referring to the `aria-label` of the button and it still achieves the same effect. 

# Screenshots

### Prior to any styling changes, the close button's X was slightly higher and not aligned to the heading, which for medium viewports (or less) we want to keep them aligned. 
<img width="944" alt="Screenshot 2023-06-09 at 11 20 09 AM" src="https://github.com/openedx/frontend-app-profile/assets/62807795/315737cf-3044-4f9d-baa9-79c792fd08ec">

### After applying the styling, the X is aligned with the heading. 
<img width="944" alt="Screenshot 2023-06-09 at 11 19 48 AM" src="https://github.com/openedx/frontend-app-profile/assets/62807795/ba5006f6-80e0-4226-832e-afb93a3ed767">
