### PR TITLE
PACT Contract Testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
-    "test": "TZ=UTC fedx-scripts jest --coverage --passWithNoTests"
+    "test": "TZ=UTC fedx-scripts jest --coverage --passWithNoTests",
+    "stubs": "$(find . -name pact-stub-service | grep -e 'bin/pact-stub-service$' | head -n 1) ./pacts/frontend-app-profile-edx-platform.json --port 18000"
   },
   "bugs": {
     "url": "https://github.com/openedx/frontend-app-profile/issues"

--- a/pacts/frontend-app-profile-edx-platform.json
+++ b/pacts/frontend-app-profile-edx-platform.json
@@ -7,21 +7,6 @@
       "description": "A request for user's basic information",
       "providerStates": [
         {
-          "name": "Account and user's information does not exist"
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "path": "/api/user/v1/accounts/staff_not_found"
-      },
-      "response": {
-        "status": 404
-      }
-    },
-    {
-      "description": "A request for user's basic information",
-      "providerStates": [
-        {
           "name": "I have a user's basic information"
         }
       ],
@@ -96,6 +81,22 @@
           "header": {}
         },
         "status": 200
+      }
+    },
+    
+    {
+      "description": "A request for user's basic information",
+      "providerStates": [
+        {
+          "name": "Account and user's information does not exist"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/user/v1/accounts/staff_not_found"
+      },
+      "response": {
+        "status": 404
       }
     }
   ],

--- a/src/pacts/frontend-app-profile-edx-platform.json
+++ b/src/pacts/frontend-app-profile-edx-platform.json
@@ -1,0 +1,215 @@
+{
+  "consumer": {
+    "name": "frontend-app-profile"
+  },
+  "interactions": [
+    {
+      "description": "A request for user's basic information",
+      "providerStates": [
+        {
+          "name": "Account does not exist"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/user/v1/accounts/staff"
+      },
+      "response": {
+        "status": 404
+      }
+    },
+    {
+      "description": "A request for a user's basic information",
+      "providerStates": [
+        {
+          "name": "I have a user's basic information"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/user/v1/accounts/staff"
+      },
+      "response": {
+        "body": {
+          "accomplishmentsShared": false,
+          "accountPrivacy": "custom",
+          "bio": "This is my bio",
+          "country": "ME",
+          "courseCertificates": null,
+          "dateJoined": "2017-06-07T00:44:23Z",
+          "email": "staff@example.com",
+          "error": null,
+          "extendedProfile": [],
+          "gender": null,
+          "goals": null,
+          "isActive": true,
+          "languageProficiencies": [
+            {
+              "code": "yo"
+            }
+          ],
+          "learningGoal": "advance_career",
+          "levelOfEducation": "el",
+          "loading": false,
+          "mailingAddress": null,
+          "name": "Lemon Seltzer",
+          "profileImage": {
+            "hasImage": true,
+            "imageUrlFull": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_500.jpg?v=1552495012",
+            "imageUrlLarge": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_120.jpg?v=1552495012",
+            "imageUrlMedium": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_50.jpg?v=1552495012",
+            "imageUrlSmall": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_30.jpg?v=1552495012"
+          },
+          "requiresParentalConsent": false,
+          "secondaryEmail": null,
+          "socialLinks": [
+            {
+              "platform": "facebook",
+              "socialLink": "https://www.facebook.com/aloha"
+            },
+            {
+              "platform": "twitter",
+              "socialLink": "https://www.twitter.com/ALOHA"
+            }
+          ],
+          "timeZone": null,
+          "username": "staff",
+          "yearOfBirth": 1901
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          },
+          "header": {}
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "A request for user's basic information",
+      "providerStates": [
+        {
+          "name": "I have a user's basic information"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/user/v1/accounts/staff"
+      },
+      "response": {
+        "body": {
+          "accomplishmentsShared": false,
+          "accountPrivacy": "custom",
+          "bio": "This is my bio",
+          "country": "ME",
+          "courseCertificates": null,
+          "dateJoined": "2017-06-07T00:44:23Z",
+          "email": "staff@example.com",
+          "error": null,
+          "extendedProfile": [],
+          "gender": null,
+          "goals": null,
+          "isActive": true,
+          "languageProficiencies": [
+            {
+              "code": "yo"
+            }
+          ],
+          "learningGoal": "advance_career",
+          "levelOfEducation": "el",
+          "loading": false,
+          "mailingAddress": null,
+          "name": "Lemon Seltzer",
+          "profileImage": {
+            "hasImage": true,
+            "imageUrlFull": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_500.jpg?v=1552495012",
+            "imageUrlLarge": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_120.jpg?v=1552495012",
+            "imageUrlMedium": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_50.jpg?v=1552495012",
+            "imageUrlSmall": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_30.jpg?v=1552495012"
+          },
+          "requiresParentalConsent": false,
+          "secondaryEmail": null,
+          "socialLinks": [
+            {
+              "platform": "facebook",
+              "socialLink": "https://www.facebook.com/aloha"
+            },
+            {
+              "platform": "twitter",
+              "socialLink": "https://www.twitter.com/ALOHA"
+            }
+          ],
+          "timeZone": null,
+          "username": "staff",
+          "yearOfBirth": 1901
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          },
+          "header": {}
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "A request for user's basic information",
+      "providerStates": [
+        {
+          "name": "I have a user's basic information"
+        },
+        {
+          "name": "Account does not exist"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/user/v1/accounts/staff"
+      },
+      "response": {
+        "status": 404
+      }
+    }
+  ],
+  "metadata": {
+    "pact-js": {
+      "version": "11.0.2"
+    },
+    "pactRust": {
+      "ffi": "0.4.0",
+      "models": "1.0.4"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "edx-platform"
+  }
+}

--- a/src/profile/data/pact-profile.test.js
+++ b/src/profile/data/pact-profile.test.js
@@ -26,7 +26,7 @@ const expectedUserInfo_200 = {
         "imageUrlFull": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_500.jpg?v=1552495012",
         "imageUrlLarge": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_120.jpg?v=1552495012",
         "imageUrlMedium": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_50.jpg?v=1552495012",
-        "imageUrlSmall": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_30.jpg?v=1552495012",
+        "imageUrlSmall": "http://localhost:18000/media/profile-im ages/d2a9bdc2ba165dcefc73265c54bf9a20_30.jpg?v=1552495012",
         "hasImage": true
     },
     "levelOfEducation": "el",
@@ -52,7 +52,6 @@ const expectedUserInfo_200 = {
 }
 
 import {initializeMockApp, getConfig, setConfig} from '@edx/frontend-platform'
-import { Console } from 'console'
 
 
 const provider = new PactV3({
@@ -62,7 +61,7 @@ const provider = new PactV3({
     provider: 'edx-platform',
   });
 
-  describe('getAccount for 1 username', () => {
+  describe('getAccount for one username', () => {
     beforeAll(async () => {
         initializeMockApp();
     });
@@ -94,9 +93,9 @@ const provider = new PactV3({
     });
 
     it('Account does not exist', async () => {
-        const username_edpt404 = 'staff'
+        const username_edpt404 = 'staff_not_found';
         await provider.addInteraction({
-            states: [{description: "Account does not exist"}],
+            states: [{description: "Account and user's information does not exist"}],
             uponReceiving: "A request for user's basic information",
             withRequest: {
                 method: "GET",

--- a/src/profile/data/pact-profile.test.js
+++ b/src/profile/data/pact-profile.test.js
@@ -1,0 +1,118 @@
+import path from 'path'
+
+import { PactV3, MatchersV3 } from '@pact-foundation/pact'
+
+import { getAccount } from './services'
+
+const expectedUserInfo_200 = {
+    "loading": false,
+    "error": null,
+    "username": "staff",
+    "email": "staff@example.com",
+    "bio": "This is my bio",
+    "name": "Lemon Seltzer",
+    "country": "ME",
+    "socialLinks": [
+    {
+        "platform": "facebook",
+        "socialLink": "https://www.facebook.com/aloha"
+    },
+    {
+        "platform": "twitter",
+        "socialLink": "https://www.twitter.com/ALOHA"
+    }
+    ],
+    "profileImage": {
+        "imageUrlFull": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_500.jpg?v=1552495012",
+        "imageUrlLarge": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_120.jpg?v=1552495012",
+        "imageUrlMedium": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_50.jpg?v=1552495012",
+        "imageUrlSmall": "http://localhost:18000/media/profile-images/d2a9bdc2ba165dcefc73265c54bf9a20_30.jpg?v=1552495012",
+        "hasImage": true
+    },
+    "levelOfEducation": "el",
+    "mailingAddress": null,
+    "extendedProfile": [],
+    "dateJoined": "2017-06-07T00:44:23Z",
+    "accomplishmentsShared": false,
+    "isActive": true,
+    "yearOfBirth": 1901,
+    "goals": null,
+    "languageProficiencies": [
+    {
+        "code": "yo"
+    }
+    ],
+    "courseCertificates": null,
+    "requiresParentalConsent": false,
+    "secondaryEmail": null,
+    "timeZone": null,
+    "gender": null,
+    "accountPrivacy": "custom",
+    "learningGoal": "advance_career"
+}
+
+import {initializeMockApp, getConfig, setConfig} from '@edx/frontend-platform'
+import { Console } from 'console'
+
+
+const provider = new PactV3({
+    log: path.resolve(process.cwd(), 'src/pact-logs/pact.log'),
+    dir: path.resolve(process.cwd(), 'src/pacts'),
+    consumer: 'frontend-app-profile',
+    provider: 'edx-platform',
+  });
+
+  describe('getAccount for 1 username', () => {
+    beforeAll(async () => {
+        initializeMockApp();
+    });
+    it('returns a HTTP 200 and user information', async () => {
+        const username_edpt200 = 'staff'
+        await provider.addInteraction({
+            states: [{description: "I have a user's basic information"}],
+            uponReceiving: "A request for user's basic information",
+            withRequest: {
+                method: "GET",
+                path: `/api/user/v1/accounts/${username_edpt200}`,
+                headers: { Accept: 'application/json'},
+            },
+            willRespondWith: {
+                status : 200,
+                headers: { 'Content-Type': 'application/json'},
+                body: MatchersV3.like(expectedUserInfo_200)
+            },
+        });
+        return provider.executeTest(async (mockserver) => {
+            const mock_port = mockserver.port;
+            setConfig({
+                ...getConfig(),
+                LMS_BASE_URL: `http://localhost:${mock_port}`,
+            });            
+            const response = await getAccount(username_edpt200);
+            expect(response).toEqual(expectedUserInfo_200);
+        })
+    });
+
+    it('Account does not exist', async () => {
+        const username_edpt404 = 'staff'
+        await provider.addInteraction({
+            states: [{description: "Account does not exist"}],
+            uponReceiving: "A request for user's basic information",
+            withRequest: {
+                method: "GET",
+                path: `/api/user/v1/accounts/${username_edpt404}`
+            },
+            willRespondWith: {
+                status: 404,
+            },
+        });
+        await provider.executeTest(async (mockserver) => {
+            const mock_port = mockserver.port;
+            setConfig({
+                ...getConfig(),
+                LMS_BASE_URL: `http://localhost:${mock_port}`,
+            });
+            await expect(getAccount(username_edpt404).then((response) => response.data)).rejects.toThrow("Request failed with status code 404");
+        });
+    });
+  });


### PR DESCRIPTION
Firstly, I added a basic contract to validate requests between the LMS and the Profile MFE in regards to the Account API endpoint. With this contract, I was able to start up a pact stub-server in a Docker container and feed this server the contract to mock the LMS in local development. Secondly, I implemented a ```stubs ``` script in ```package.json```  that will start the stub server on any given port. This can be run by using ```npm run stubs```.
