### PR TITLE
build: add catalog-info yaml and update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,57 +1,127 @@
-|Build Status| |Codecov| |license|
-
 frontend-app-profile
-====================
+##########################
 
-This is a micro-frontend application responsible for the display and updating of user profiles. Please tag **@openedx/2u-aperture** on any PRs or issues.
+|license-badge| |status-badge| |ci-badge| |codecov-badge|
+
+.. |license-badge| image:: https://img.shields.io/github/license/openedx/frontend-app-profile.svg
+    :target: https://github.com/openedx/frontend-app-profile/blob/main/LICENSE
+    :alt: License
+
+.. |status-badge| image:: https://img.shields.io/badge/Status-Maintained-brightgreen
+
+.. |ci-badge| image:: https://github.com/openedx/frontend-app-profile/actions/workflows/ci.yml/badge.svg
+    :target: https://github.com/openedx/frontend-app-profile/actions/workflows/ci.yml
+    :alt: Continuous Integration
+
+.. |codecov-badge| image:: https://codecov.io/github/openedx/frontend-app-profile/coverage.svg?branch=main
+    :target: https://codecov.io/github/openedx/frontend-app-profile?branch=main
+    :alt: Codecov
+
+Purpose
+=======
+
+This is a micro-frontend application responsible for the display and updating of user profiles.
 
 When a user views their own profile, they're given fields to edit their full name, location, primary spoken language, education, social links, and bio.  Each field also has a dropdown to select the visibility of that field - i.e., whether it can be viewed by other learners.
 
 When a user views someone else's profile, they see all those fields that that user set as public.
 
-----------
+Getting Started
+===============
 
-Development
------------
+Devstack Installation
+---------------------
 
-Start Devstack
-^^^^^^^^^^^^^^
+Follow these steps to provision, run, and enable an instance of the
+Profile MFE for local development via the `devstack`_.
 
-To use this application `devstack <https://github.com/openedx/devstack>`__ must be running and you must be logged into it.
+.. _devstack: https://github.com/openedx/devstack#getting-started
 
--  Start devstack
--  Log in (http://localhost:18000/login)
+#. To use this application, `devstack <https://github.com/openedx/devstack>`__ must be running and you must be logged into it.
 
-Start the development server
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   * Start devstack
+   * Log in (http://localhost:18000/login)
 
-In this project, install requirements and start the development server by running:
+#. To run Profile, install requirements and start the development server by running:
 
-.. code:: bash
+.. code-block::
 
    npm install
    npm start # The server will run on port 1995
 
-Once the dev server is up visit http://localhost:1995/u/staff.
+Once the dev server is up, visit http://localhost:1995/u/staff.
 
-----------
-
-Configuration and Deployment
-----------------------------
+Configuration
+-------------
 
 This MFE is configured via node environment variables supplied at build time. See the .env file for the list of required environment variables. Example build syntax with a single environment variable:
 
-.. code:: bash
+.. code-block::
 
    NODE_ENV=production ACCESS_TOKEN_COOKIE_NAME='edx-jwt-cookie-header-payload' npm run build
 
+Getting Help
+============
 
-For more information see the document: `Micro-frontend applications in Open
-edX <https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/micro-frontends-in-open-edx.html>`__.
+If you're having trouble, we have discussion forums at
+https://discuss.openedx.org where you can connect with others in the community.
 
-.. |Build Status| image:: https://api.travis-ci.org/edx/frontend-app-profile.svg?branch=master
-   :target: https://travis-ci.org/edx/frontend-app-profile
-.. |Codecov| image:: https://img.shields.io/codecov/c/github/edx/frontend-app-profile
-   :target: https://codecov.io/gh/edx/frontend-app-profile
-.. |license| image:: https://img.shields.io/npm/l/@edx/frontend-app-profile.svg
-   :target: @edx/frontend-app-profile
+Our real-time conversations are on Slack. You can request a `Slack
+invitation`_, then join our `community Slack workspace`_.  Because this is a
+frontend repository, the best place to discuss it would be in the `#wg-frontend
+channel`_.
+
+For anything non-trivial, the best path is to open an issue in this repository
+with as many details about the issue you are facing as you can provide.  Please tag **@openedx/2u-aperture** on any PRs or issues.
+
+https://github.com/openedx/frontend-app-profile/issues
+
+For more information about these options, see the `Getting Help`_ page.
+
+.. _Slack invitation: https://openedx.org/slack
+.. _community Slack workspace: https://openedx.slack.com/
+.. _#wg-frontend channel: https://openedx.slack.com/archives/C04BM6YC7A6
+.. _Getting Help: https://openedx.org/getting-help
+
+License
+=======
+
+The code in this repository is licensed under the AGPLv3 unless otherwise
+noted.
+
+Please see `LICENSE <LICENSE>`_ for details.
+
+Contributing
+============
+
+Contributions are very welcome.  Please read `How To Contribute`_ for details.
+
+.. _How To Contribute: https://openedx.org/r/how-to-contribute
+
+This project is currently accepting all types of contributions, bug fixes,
+security fixes, maintenance work, or new features.  However, please make sure
+to have a discussion about your new feature idea with the maintainers prior to
+beginning development to maximize the chances of your change being accepted.
+You can start a conversation by creating a new issue on this repo summarizing
+your idea.
+
+The Open edX Code of Conduct
+============================
+
+All community members are expected to follow the `Open edX Code of Conduct`_.
+
+.. _Open edX Code of Conduct: https://openedx.org/code-of-conduct/
+
+People
+======
+
+The assigned maintainers for this component and other project details may be
+found in `Backstage`_. Backstage pulls this data from the ``catalog-info.yaml``
+file in this repo.
+
+.. _Backstage: https://backstage.herokuapp.com/catalog/default/component/frontend-app-profile
+
+Reporting Security Issues
+=========================
+
+Please do not report security issues in public.  Email security@openedx.org instead.

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,24 @@
+# This file records information about this repo. Its use is described in OEP-55:
+# https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: 'Profile'
+  description: 'This is a micro-frontend application responsible for the display and updating of user profiles.'
+  links:
+    - url: 'https://github.com/openedx/frontend-app-profile/blob/master/README.rst'
+      title: 'Documentation'
+      icon: 'Article'
+  annotations:
+    # (Optional) Annotation keys and values can be whatever you want.
+    # We use it in Open edX repos to have a comma-separated list of GitHub user
+    # names that might be interested in changes to the architecture of this
+    # component.
+    openedx.org/arch-interest-groups: ""
+    # This can be multiple comma-separated projects.
+    openedx.org/add-to-projects: "openedx:23"
+spec:
+  type: 'service'
+  lifecycle: 'production'
+  owner: 2U-aperture
+# (Optional) An array of different components or resources.


### PR DESCRIPTION
### Description

These updates and additions meet the [Maintainership Pilot Phase 1 requirements](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3578691585/Pilot+Phase+1) by providing a `catalog-info.yaml` file ([source](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055/decisions/0001-use-backstage-to-support-maintainers.html)) and updating the README to match [the template provided](https://github.com/openedx/frontend-template-application/blob/master/README-template-frontend-app.rst). 