### PR TITLE
fix: Add ID attribute to the main content

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -32,7 +32,7 @@ subscribe(APP_READY, () => {
     <AppProvider store={configureStore()}>
       <Head />
       <Header />
-      <main>
+      <main id="main">
         <AppRoutes />
       </main>
       <Footer />


### PR DESCRIPTION
Added the missing 'ID' parameter for the main section. When we want to use keyboard navigation through the page, the first anchor we encounter on the account page is 'Skip to main content,' which allows us to skip the header and move to the content area. However, this anchor is linked to the #main ID, which is missing in the main section.

Before fix:

https://github.com/openedx/frontend-app-profile/assets/19806032/1bb407ae-51e0-4cc9-bbff-5aa30c56fe0c

After:

https://github.com/openedx/frontend-app-profile/assets/19806032/f3a4d83e-6aeb-426e-beda-5b0702f9b77d
