### PR TITLE
fix: "view public profile" link sends parent frame to URL

### DIFF
--- a/src/profile/ProfilePluginPage.jsx
+++ b/src/profile/ProfilePluginPage.jsx
@@ -87,7 +87,7 @@ class ProfilePluginPage extends React.Component {
           <Card.Header
             className="pb-5"
             subtitle={(
-              <Hyperlink destination={`/u/${this.props.params.username}`}>
+              <Hyperlink destination={`/u/${this.props.params.username}`} target="_parent">
                 View public profile
               </Hyperlink>
             )}


### PR DESCRIPTION
Context:
The Profile plugin component has a `view public profile` hyperlink, then when clicked would redirect the page _inside the plugin_ rather than the parent frame (AKA Host MFE).

This PR fixes that bug by adding `target=_parent` to the Hyperlink tag. 