### PR TITLE
fix: get `@edx/openedx-atlas` back to fix Tutor MFE | FC-0012

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@edx/frontend-component-footer": "13.0.2",
         "@edx/frontend-component-header": "5.0.2",
         "@edx/frontend-platform": "7.1.0",
+        "@edx/openedx-atlas": "^0.6.0",
         "@fortawesome/fontawesome-svg-core": "6.5.1",
         "@fortawesome/free-brands-svg-icons": "6.5.1",
         "@fortawesome/free-regular-svg-icons": "6.5.1",
@@ -2783,6 +2784,14 @@
       "integrity": "sha512-OrlvtdsPcWuOm6NBWfUxFE06qdPiu2bf9nU4I9t8Lu7WW6NsosAB5hxm5U+MBMZP2AuVl3FAt0k0lZsu3+ri8Q==",
       "dependencies": {
         "@newrelic/publish-sourcemap": "^5.0.1"
+      }
+    },
+    "node_modules/@edx/openedx-atlas": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@edx/openedx-atlas/-/openedx-atlas-0.6.0.tgz",
+      "integrity": "sha512-wZO7hA4VJ/bXjaQNNR7KXGYyTCNs1mBJd3HwQK2EmOwFZYFNX6nzSAm9S7HCfi/kb1PCRpmp3wJt+v/Eu9BEQg==",
+      "bin": {
+        "atlas": "atlas"
       }
     },
     "node_modules/@edx/reactifex": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@edx/frontend-component-footer": "13.0.2",
     "@edx/frontend-component-header": "5.0.2",
     "@edx/frontend-platform": "7.1.0",
+    "@edx/openedx-atlas": "^0.6.0",
     "@fortawesome/fontawesome-svg-core": "6.5.1",
     "@fortawesome/free-brands-svg-icons": "6.5.1",
     "@fortawesome/free-regular-svg-icons": "6.5.1",


### PR DESCRIPTION
This is a partial revert for bd4b79baa0fb2a82b713a807f4a67bdbd42f93a9 which broke Tutor MFE.

- Tutor MFE issue: https://github.com/overhangio/tutor-mfe/pull/184#issuecomment-1966857727

I understand that the package is still `@edx` but until we set up the `@openedx` version, the current version must be used.

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
