### PR TITLE
revert: "chore(deps): update dependency @testing-library/react to v14"

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@edx/reactifex": "2.2.0",
     "@openedx/frontend-build": "13.0.30",
     "@testing-library/jest-dom": "6.4.2",
-    "@testing-library/react": "14.2.2",
+    "@testing-library/react": "12.1.5",
     "glob": "10.3.10",
     "reactifex": "1.1.1",
     "redux-mock-store": "1.5.4"


### PR DESCRIPTION
This reverts commit a3611b026c6933bfcd91ea102e79fa298a6c8f75. This version of `testing-library/react` doesn't play well with our current version of React.

We shouldn't upgrade this library until we're running a newer version of React in this MFE.