### PR TITLE
chore(deps): upgrade to paragon v22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@fortawesome/free-regular-svg-icons": "6.5.2",
         "@fortawesome/free-solid-svg-icons": "6.5.2",
         "@fortawesome/react-fontawesome": "0.2.0",
-        "@openedx/paragon": "21.13.1",
+        "@openedx/paragon": "^22.2.2",
         "@pact-foundation/pact": "^11.0.2",
         "@redux-devtools/extension": "3.3.0",
         "classnames": "2.5.1",
@@ -5851,9 +5851,9 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "21.13.1",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-21.13.1.tgz",
-      "integrity": "sha512-sLL+Z3ZWIRM6x+OrKZV0S7/SQpEcSeRcDm7E3FzhsnAWudsJCTELvSW+84uy/8dwV7mJhttsBPqQEtNafbCyYA==",
+      "version": "22.2.2",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.2.2.tgz",
+      "integrity": "sha512-kHljO3JjLQzkk16aOIUN+LbSVMF9a6jkO0G9CmAYhYRDZMpWlP8qUz5uWk7pJvQdCoqD2dL9Cp9YqhWLXCa2kQ==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@fortawesome/free-regular-svg-icons": "6.5.2",
     "@fortawesome/free-solid-svg-icons": "6.5.2",
     "@fortawesome/react-fontawesome": "0.2.0",
-    "@openedx/paragon": "21.13.1",
+    "@openedx/paragon": "^22.2.2",
     "@pact-foundation/pact": "^11.0.2",
     "@redux-devtools/extension": "3.3.0",
     "classnames": "2.5.1",


### PR DESCRIPTION
Upgrade to Paragon v22. The breaking changes are for components that are not used by this MFE (see [release notes](https://github.com/openedx/paragon/releases/tag/v22.0.0))