### PR TITLE
fix: make raw string a formatted message

### DIFF
--- a/src/profile/AgeMessage.jsx
+++ b/src/profile/AgeMessage.jsx
@@ -11,7 +11,11 @@ const AgeMessage = ({ accountSettingsUrl }) => (
     show
   >
     <Alert.Heading id="profile.age.headline">
-      Your profile cannot be shared.
+      <FormattedMessage
+        id="profile.age.cannotShare"
+        defaultMessage="Your profile cannot be shared."
+        description="Error message indicating that the user's profile cannot be shared"
+      />
     </Alert.Heading>
     <FormattedMessage
       id="profile.age.details"


### PR DESCRIPTION
Before this, the "Your profile cannot be shared." sentence was hardcoded and not translated.
@openedx/2u-aperture kindly have a look.

Close #1040