### PR TITLE
feat: extend the profile fields with the already existing extended_profile_fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5847,18 +5847,18 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
     },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
-      "license": "MIT"
-    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
+      "license": "MIT"
     },
     "node_modules/@types/warning": {
       "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@redux-devtools/extension": "3.3.0",
         "classnames": "2.5.1",
         "core-js": "3.42.0",
+        "dompurify": "3.2.4",
         "history": "5.3.0",
         "lodash.camelcase": "4.3.0",
         "lodash.get": "4.4.2",
@@ -5852,6 +5853,13 @@
       "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/warning": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
@@ -9232,6 +9240,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@redux-devtools/extension": "3.3.0",
     "classnames": "2.5.1",
     "core-js": "3.42.0",
+    "dompurify": "3.2.4",
     "history": "5.3.0",
     "lodash.camelcase": "4.3.0",
     "lodash.get": "4.4.2",

--- a/src/profile/ProfilePage.jsx
+++ b/src/profile/ProfilePage.jsx
@@ -17,6 +17,7 @@ import {
   openForm,
   closeForm,
   updateDraft,
+  getExtendedProfileFields as fetchExtraFieldsInfo,
 } from './data/actions';
 
 // Components
@@ -42,6 +43,7 @@ import { profilePageSelector } from './data/selectors';
 import messages from './ProfilePage.messages';
 
 import withParams from '../utils/hoc';
+import ExtendedProfileFields from './forms/ExtendedProfileFields';
 
 ensureConfig(['CREDENTIALS_BASE_URL', 'LMS_BASE_URL'], 'ProfilePage');
 
@@ -65,6 +67,7 @@ class ProfilePage extends React.Component {
 
   componentDidMount() {
     this.props.fetchProfile(this.props.params.username);
+    this.props.fetchExtraFieldsInfo({ is_register_page: true });
     sendTrackingLogEvent('edx.profile.viewed', {
       username: this.props.params.username,
     });
@@ -291,6 +294,13 @@ class ProfilePage extends React.Component {
             )}
           </div>
           <div className="pt-md-3 col-md-8 col-lg-7 offset-lg-1">
+            {this.props.extendedProfileFields.length > 0 && (
+              <ExtendedProfileFields
+                extendedProfileFields={this.props.extendedProfileFields}
+                formId="extendedProfile"
+                {...commonFormProps}
+              />
+            )}
             {!this.isYOBDisabled() && this.renderAgeMessage()}
             {isBioBlockVisible && (
               <Bio
@@ -368,6 +378,28 @@ ProfilePage.propTypes = {
   name: PropTypes.string,
   visibilityName: PropTypes.string.isRequired,
 
+  // Extra profile fields
+  extendedProfileFields: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    default: PropTypes.unknown,
+    placeholder: PropTypes.string,
+    instructions: PropTypes.string,
+    options: PropTypes.arrayOf(PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    })),
+    error_message: PropTypes.shape({
+      required: PropTypes.string,
+      invalid: PropTypes.string,
+    }),
+    restrictions: PropTypes.shape({
+      max_length: PropTypes.number,
+    }),
+    type: PropTypes.string.isRequired,
+    value: PropTypes.unknown,
+  })),
+
   // Social links form data
   socialLinks: PropTypes.arrayOf(PropTypes.shape({
     platform: PropTypes.string,
@@ -404,6 +436,7 @@ ProfilePage.propTypes = {
   closeForm: PropTypes.func.isRequired,
   updateDraft: PropTypes.func.isRequired,
   navigate: PropTypes.func.isRequired,
+  fetchExtraFieldsInfo: PropTypes.func.isRequired,
 
   // Router
   params: PropTypes.shape({
@@ -432,6 +465,7 @@ ProfilePage.defaultProps = {
   courseCertificates: null,
   requiresParentalConsent: null,
   dateJoined: null,
+  extendedProfileFields: [],
 };
 
 export default connect(
@@ -444,5 +478,6 @@ export default connect(
     openForm,
     closeForm,
     updateDraft,
+    fetchExtraFieldsInfo,
   },
 )(injectIntl(withParams(ProfilePage)));

--- a/src/profile/ProfilePage.jsx
+++ b/src/profile/ProfilePage.jsx
@@ -67,7 +67,7 @@ class ProfilePage extends React.Component {
 
   componentDidMount() {
     this.props.fetchProfile(this.props.params.username);
-    this.props.fetchExtraFieldsInfo({ is_register_page: true });
+    this.props.fetchExtraFieldsInfo();
     sendTrackingLogEvent('edx.profile.viewed', {
       username: this.props.params.username,
     });
@@ -396,7 +396,7 @@ ProfilePage.propTypes = {
       label: PropTypes.string.isRequired,
     })),
     // https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/user_api/helpers.py#L179
-    error_message: PropTypes.shape({
+    errorMessage: PropTypes.shape({
       required: PropTypes.string,
     }),
     // https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/user_api/helpers.py#L167

--- a/src/profile/ProfilePage.jsx
+++ b/src/profile/ProfilePage.jsx
@@ -217,8 +217,8 @@ class ProfilePage extends React.Component {
     const isCertificatesBlockVisible = isBlockVisible(courseCertificates.length);
     const isNameBlockVisible = isBlockVisible(name);
     const isLocationBlockVisible = isBlockVisible(country);
-    // TODO: modify /api/user/v1/accounts/{{username}} to return extended profile fields
-    // So this can be shown for no-authenticated user profiles
+    // TODO: modify /api/user/v1/accounts/{{username}} to return extended profile field values
+    // So these fields can be shown for no-authenticated user profiles
     const isExtendedProfileFieldsVisible = isBlockVisible(
       extendedProfileFields.length > 0 && this.isAuthenticatedUserProfile(),
     );

--- a/src/profile/ProfilePage.jsx
+++ b/src/profile/ProfilePage.jsx
@@ -189,6 +189,7 @@ class ProfilePage extends React.Component {
       username,
       saveState,
       navigate,
+      extendedProfileFields,
     } = this.props;
 
     if (isLoadingProfile) {
@@ -216,6 +217,11 @@ class ProfilePage extends React.Component {
     const isCertificatesBlockVisible = isBlockVisible(courseCertificates.length);
     const isNameBlockVisible = isBlockVisible(name);
     const isLocationBlockVisible = isBlockVisible(country);
+    // TODO: modify /api/user/v1/accounts/{{username}} to return extended profile fields
+    // So this can be shown for no-authenticated user profiles
+    const isExtendedProfileFieldsVisible = isBlockVisible(
+      extendedProfileFields.length > 0 && this.isAuthenticatedUserProfile(),
+    );
 
     return (
       <div className="container-fluid">
@@ -283,6 +289,13 @@ class ProfilePage extends React.Component {
                 {...commonFormProps}
               />
             )}
+            {isExtendedProfileFieldsVisible && (
+            <ExtendedProfileFields
+              extendedProfileFields={extendedProfileFields}
+              formId="extendedProfile"
+              {...commonFormProps}
+            />
+            )}
             {isSocialLinksBLockVisible && (
               <SocialLinks
                 socialLinks={socialLinks}
@@ -294,13 +307,6 @@ class ProfilePage extends React.Component {
             )}
           </div>
           <div className="pt-md-3 col-md-8 col-lg-7 offset-lg-1">
-            {this.props.extendedProfileFields.length > 0 && (
-              <ExtendedProfileFields
-                extendedProfileFields={this.props.extendedProfileFields}
-                formId="extendedProfile"
-                {...commonFormProps}
-              />
-            )}
             {!this.isYOBDisabled() && this.renderAgeMessage()}
             {isBioBlockVisible && (
               <Bio

--- a/src/profile/ProfilePage.jsx
+++ b/src/profile/ProfilePage.jsx
@@ -290,11 +290,11 @@ class ProfilePage extends React.Component {
               />
             )}
             {isExtendedProfileFieldsVisible && (
-            <ExtendedProfileFields
-              extendedProfileFields={extendedProfileFields}
-              formId="extendedProfile"
-              {...commonFormProps}
-            />
+              <ExtendedProfileFields
+                extendedProfileFields={extendedProfileFields}
+                formId="extendedProfile"
+                {...commonFormProps}
+              />
             )}
             {isSocialLinksBLockVisible && (
               <SocialLinks
@@ -395,13 +395,16 @@ ProfilePage.propTypes = {
       value: PropTypes.string.isRequired,
       label: PropTypes.string.isRequired,
     })),
+    // https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/user_api/helpers.py#L179
     error_message: PropTypes.shape({
       required: PropTypes.string,
-      invalid: PropTypes.string,
     }),
+    // https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/user_api/helpers.py#L167
     restrictions: PropTypes.shape({
       max_length: PropTypes.number,
+      min_length: PropTypes.number,
     }),
+    // https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/user_api/helpers.py#L151
     type: PropTypes.string.isRequired,
     value: PropTypes.unknown,
   })),

--- a/src/profile/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/profile/__snapshots__/ProfilePage.test.jsx.snap
@@ -442,6 +442,7 @@ exports[`<ProfilePage /> Renders correctly in various states successfully redire
               </div>
             </div>
           </div>
+          <div />
           <div
             class="pgn-transition-replace-group position-relative mb-5"
           >
@@ -2483,6 +2484,7 @@ exports[`<ProfilePage /> Renders correctly in various states test country edit w
               </p>
             </div>
           </div>
+          <div />
           <div
             class="pgn-transition-replace-group position-relative mb-5"
           >
@@ -3482,6 +3484,7 @@ exports[`<ProfilePage /> Renders correctly in various states test education edit
               </div>
             </div>
           </div>
+          <div />
           <div
             class="pgn-transition-replace-group position-relative mb-5"
           >
@@ -5356,6 +5359,7 @@ exports[`<ProfilePage /> Renders correctly in various states test preferreded la
               </p>
             </div>
           </div>
+          <div />
           <div
             class="pgn-transition-replace-group position-relative mb-5"
           >
@@ -6076,6 +6080,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing other profi
               </p>
             </div>
           </div>
+          <div />
           <div
             class="pgn-transition-replace-group position-relative mb-5"
           >
@@ -6639,6 +6644,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
               </p>
             </div>
           </div>
+          <div />
           <div
             class="pgn-transition-replace-group position-relative mb-5"
           >
@@ -7516,6 +7522,7 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
               </p>
             </div>
           </div>
+          <div />
           <div
             class="pgn-transition-replace-group position-relative mb-5"
           >
@@ -8457,6 +8464,7 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
               </p>
             </div>
           </div>
+          <div />
           <div
             class="pgn-transition-replace-group position-relative mb-5"
           >
@@ -9326,6 +9334,7 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
               </p>
             </div>
           </div>
+          <div />
           <div
             class="pgn-transition-replace-group position-relative mb-5"
           >

--- a/src/profile/data/actions.js
+++ b/src/profile/data/actions.js
@@ -147,3 +147,29 @@ export const updateDraft = (name, value) => ({
 export const resetDrafts = () => ({
   type: RESET_DRAFTS,
 });
+
+// Third party auth context
+export const EXTENDED_PROFILE_FIELDS = new AsyncActionType('EXTENDED_PROFILE_FIELDS', 'GET_EXTENDED_PROFILE_FIELDS');
+export const EXTENDED_PROFILE_FIELDS_CLEAR_ERROR_MSG = 'EXTENDED_PROFILE_FIELDS_CLEAR_ERROR_MSG';
+
+export const getExtendedProfileFields = (urlParams) => ({
+  type: EXTENDED_PROFILE_FIELDS.BASE,
+  payload: { urlParams },
+});
+
+export const getExtendedProfileFieldsBegin = () => ({
+  type: EXTENDED_PROFILE_FIELDS.BEGIN,
+});
+
+export const getExtendedProfileFieldsSuccess = (fields) => ({
+  type: EXTENDED_PROFILE_FIELDS.SUCCESS,
+  payload: fields,
+});
+
+export const getExtendedProfileFieldsFailure = () => ({
+  type: EXTENDED_PROFILE_FIELDS.FAILURE,
+});
+
+export const clearThirdPartyAuthContextErrorMessage = () => ({
+  type: EXTENDED_PROFILE_FIELDS_CLEAR_ERROR_MSG,
+});

--- a/src/profile/data/actions.js
+++ b/src/profile/data/actions.js
@@ -148,13 +148,11 @@ export const resetDrafts = () => ({
   type: RESET_DRAFTS,
 });
 
-// Third party auth context
 export const EXTENDED_PROFILE_FIELDS = new AsyncActionType('EXTENDED_PROFILE_FIELDS', 'GET_EXTENDED_PROFILE_FIELDS');
 export const EXTENDED_PROFILE_FIELDS_CLEAR_ERROR_MSG = 'EXTENDED_PROFILE_FIELDS_CLEAR_ERROR_MSG';
 
-export const getExtendedProfileFields = (urlParams) => ({
+export const getExtendedProfileFields = () => ({
   type: EXTENDED_PROFILE_FIELDS.BASE,
-  payload: { urlParams },
 });
 
 export const getExtendedProfileFieldsBegin = () => ({
@@ -168,8 +166,4 @@ export const getExtendedProfileFieldsSuccess = (fields) => ({
 
 export const getExtendedProfileFieldsFailure = () => ({
   type: EXTENDED_PROFILE_FIELDS.FAILURE,
-});
-
-export const clearThirdPartyAuthContextErrorMessage = () => ({
-  type: EXTENDED_PROFILE_FIELDS_CLEAR_ERROR_MSG,
 });

--- a/src/profile/data/reducers.js
+++ b/src/profile/data/reducers.js
@@ -130,11 +130,23 @@ const profilePage = (state = initialState, action = {}) => {
         errors: {},
       };
 
-    case UPDATE_DRAFT:
+    case UPDATE_DRAFT: {
+      const { name, value } = action.payload;
+      const updatedDrafts = { ...state.drafts, [name]: value };
+
+      if (name === 'visibilityExtendedProfile') {
+        const visibilityExtendedProfile = {
+          ...state.preferences.visibilityExtendedProfile,
+          ...value,
+        };
+        updatedDrafts[name] = visibilityExtendedProfile;
+      }
+
       return {
         ...state,
-        drafts: { ...state.drafts, [action.payload.name]: action.payload.value },
+        drafts: updatedDrafts,
       };
+    }
 
     case RESET_DRAFTS:
       return {

--- a/src/profile/data/reducers.js
+++ b/src/profile/data/reducers.js
@@ -7,6 +7,7 @@ import {
   FETCH_PROFILE,
   UPDATE_DRAFT,
   RESET_DRAFTS,
+  EXTENDED_PROFILE_FIELDS,
 } from './actions';
 
 export const initialState = {
@@ -22,6 +23,7 @@ export const initialState = {
   drafts: {},
   isLoadingProfile: true,
   isAuthenticatedUserProfile: false,
+  extendedProfileFields: [],
 };
 
 const profilePage = (state = initialState, action = {}) => {
@@ -155,6 +157,14 @@ const profilePage = (state = initialState, action = {}) => {
         };
       }
       return state;
+    case EXTENDED_PROFILE_FIELDS.BEGIN:
+    case EXTENDED_PROFILE_FIELDS.FAILURE:
+    case EXTENDED_PROFILE_FIELDS.SUCCESS:
+      if (!action.payload) { return state; }
+      return {
+        ...state,
+        extendedProfileFields: action.payload,
+      };
     default:
       return state;
   }

--- a/src/profile/data/sagas.js
+++ b/src/profile/data/sagas.js
@@ -97,7 +97,7 @@ export function* handleFetchProfile(action) {
 
     yield put(fetchProfileReset());
   } catch (e) {
-    if (e.response.status === 404) {
+    if (e.response?.status === 404) {
       if (e.processedData && e.processedData.fieldErrors) {
         yield put(saveProfileFailure(e.processedData.fieldErrors));
       } else {

--- a/src/profile/data/sagas.js
+++ b/src/profile/data/sagas.js
@@ -210,12 +210,12 @@ export function* handleDeleteProfilePhoto(action) {
   }
 }
 
-export function* fetchThirdPartyAuthContext(action) {
+export function* fetchExtendedProfileFields() {
   try {
     yield put(getExtendedProfileFieldsBegin());
     const {
       fields,
-    } = yield call(ProfileApiService.getExtendedProfileFields, action.payload.urlParams);
+    } = yield call(ProfileApiService.getExtendedProfileFields);
 
     yield put(getExtendedProfileFieldsSuccess(fields));
   } catch (e) {
@@ -229,5 +229,5 @@ export default function* profileSaga() {
   yield takeEvery(SAVE_PROFILE.BASE, handleSaveProfile);
   yield takeEvery(SAVE_PROFILE_PHOTO.BASE, handleSaveProfilePhoto);
   yield takeEvery(DELETE_PROFILE_PHOTO.BASE, handleDeleteProfilePhoto);
-  yield takeEvery(EXTENDED_PROFILE_FIELDS.BASE, fetchThirdPartyAuthContext);
+  yield takeEvery(EXTENDED_PROFILE_FIELDS.BASE, fetchExtendedProfileFields);
 }

--- a/src/profile/data/sagas.js
+++ b/src/profile/data/sagas.js
@@ -29,6 +29,10 @@ import {
   saveProfileSuccess,
   SAVE_PROFILE,
   SAVE_PROFILE_PHOTO,
+  EXTENDED_PROFILE_FIELDS,
+  getExtendedProfileFieldsBegin,
+  getExtendedProfileFieldsSuccess,
+  getExtendedProfileFieldsFailure,
 } from './actions';
 import { handleSaveProfileSelector, userAccountSelector } from './selectors';
 import * as ProfileApiService from './services';
@@ -117,6 +121,7 @@ export function* handleSaveProfile(action) {
       'languageProficiencies',
       'name',
       'socialLinks',
+      'extendedProfile',
     ]);
 
     const preferencesDrafts = pick(drafts, [
@@ -204,9 +209,24 @@ export function* handleDeleteProfilePhoto(action) {
   }
 }
 
+export function* fetchThirdPartyAuthContext(action) {
+  try {
+    yield put(getExtendedProfileFieldsBegin());
+    const {
+      fields,
+    } = yield call(ProfileApiService.getExtendedProfileFields, action.payload.urlParams);
+
+    yield put(getExtendedProfileFieldsSuccess(fields));
+  } catch (e) {
+    yield put(getExtendedProfileFieldsFailure());
+    throw e;
+  }
+}
+
 export default function* profileSaga() {
   yield takeEvery(FETCH_PROFILE.BASE, handleFetchProfile);
   yield takeEvery(SAVE_PROFILE.BASE, handleSaveProfile);
   yield takeEvery(SAVE_PROFILE_PHOTO.BASE, handleSaveProfilePhoto);
   yield takeEvery(DELETE_PROFILE_PHOTO.BASE, handleDeleteProfilePhoto);
+  yield takeEvery(EXTENDED_PROFILE_FIELDS.BASE, fetchThirdPartyAuthContext);
 }

--- a/src/profile/data/sagas.js
+++ b/src/profile/data/sagas.js
@@ -132,6 +132,7 @@ export function* handleSaveProfile(action) {
       'visibilityLanguageProficiencies',
       'visibilityName',
       'visibilitySocialLinks',
+      'visibilityExtendedProfile',
     ]);
 
     if (Object.keys(preferencesDrafts).length > 0) {

--- a/src/profile/data/sagas.test.js
+++ b/src/profile/data/sagas.test.js
@@ -32,6 +32,7 @@ import profileSaga, {
   handleSaveProfile,
   handleSaveProfilePhoto,
   handleDeleteProfilePhoto,
+  fetchThirdPartyAuthContext,
 } from './sagas';
 import * as ProfileApiService from './services';
 /* eslint-enable import/first */
@@ -49,6 +50,8 @@ describe('RootSaga', () => {
         .toEqual(takeEvery(profileActions.SAVE_PROFILE_PHOTO.BASE, handleSaveProfilePhoto));
       expect(gen.next().value)
         .toEqual(takeEvery(profileActions.DELETE_PROFILE_PHOTO.BASE, handleDeleteProfilePhoto));
+      expect(gen.next().value)
+        .toEqual(takeEvery(profileActions.EXTENDED_PROFILE_FIELDS.BASE, fetchThirdPartyAuthContext));
 
       expect(gen.next().value).toBeUndefined();
     });

--- a/src/profile/data/sagas.test.js
+++ b/src/profile/data/sagas.test.js
@@ -35,7 +35,7 @@ import profileSaga, {
   handleSaveProfile,
   handleSaveProfilePhoto,
   handleDeleteProfilePhoto,
-  fetchThirdPartyAuthContext,
+  fetchExtendedProfileFields,
 } from './sagas';
 import * as ProfileApiService from './services';
 /* eslint-enable import/first */
@@ -54,7 +54,7 @@ describe('RootSaga', () => {
       expect(gen.next().value)
         .toEqual(takeEvery(profileActions.DELETE_PROFILE_PHOTO.BASE, handleDeleteProfilePhoto));
       expect(gen.next().value)
-        .toEqual(takeEvery(profileActions.EXTENDED_PROFILE_FIELDS.BASE, fetchThirdPartyAuthContext));
+        .toEqual(takeEvery(profileActions.EXTENDED_PROFILE_FIELDS.BASE, fetchExtendedProfileFields));
 
       expect(gen.next().value).toBeUndefined();
     });
@@ -170,7 +170,7 @@ describe('RootSaga', () => {
     });
   });
 
-  describe('fetchThirdPartyAuthContext', () => {
+  describe('fetchExtendedProfileFields', () => {
     test('should fetch third party auth context', async () => {
       const dispatched = [];
       const mockedAction = { payload: { urlParams: {} } };
@@ -182,7 +182,7 @@ describe('RootSaga', () => {
         {
           dispatch: (action) => dispatched.push(action),
         },
-        fetchThirdPartyAuthContext,
+        fetchExtendedProfileFields,
         mockedAction,
       ).toPromise();
 
@@ -200,7 +200,7 @@ describe('RootSaga', () => {
         {
           dispatch: (action) => dispatched.push(action),
         },
-        fetchThirdPartyAuthContext,
+        fetchExtendedProfileFields,
         mockedAction,
       ).toPromise()).rejects.toThrow('API error');
 

--- a/src/profile/data/selectors.js
+++ b/src/profile/data/selectors.js
@@ -409,7 +409,7 @@ export const profilePageSelector = createSelector(
 
     // Extended profile fields
     // Combine the field properties and its values
-    extendedProfileFields: extendedProfileFields.map((field) => ({
+    extendedProfileFields: extendedProfileFields?.map((field) => ({
       ...field,
       value: account.extendedProfile?.find(
         (extendedProfileField) => extendedProfileField.fieldName === field.name,

--- a/src/profile/data/selectors.js
+++ b/src/profile/data/selectors.js
@@ -32,10 +32,17 @@ export const editableFormModeSelector = createSelector(
   formIdSelector,
   currentlyEditingFieldSelector,
   (account, isAuthenticatedUserProfile, certificates, formId, currentlyEditingField) => {
+    const [parentPropKey, fieldName] = formId.split('/');
     // If the prop doesn't exist, that means it hasn't been set (for the current user's profile)
     // or is being hidden from us (for other users' profiles)
     let propExists = account[formId] != null && account[formId].length > 0;
     propExists = formId === 'certificates' ? certificates.length > 0 : propExists; // overwrite for certificates
+
+    // Overwrite for extended profile fields
+    propExists = formId.includes('extendedProfile') ? (
+      account[parentPropKey]?.some((field) => field.fieldName === fieldName)
+    ) : propExists;
+
     // If this isn't the current user's profile
     if (!isAuthenticatedUserProfile) {
       return 'static';

--- a/src/profile/data/selectors.js
+++ b/src/profile/data/selectors.js
@@ -246,9 +246,16 @@ export const visibilitiesSelector = createSelector(
           visibilityLanguageProficiencies: preferences.visibilityLanguageProficiencies || 'all_users',
           visibilityName: preferences.visibilityName || 'all_users',
           visibilitySocialLinks: preferences.visibilitySocialLinks || 'all_users',
-          visibilityExtendedProfile: preferences.visibilityExtendedProfile || 'all_users',
+          visibilityExtendedProfile: preferences.visibilityExtendedProfile || {},
         };
-      case 'private':
+      case 'private': {
+        const visibilityExtendedProfile = {};
+
+        if (preferences.visibilityExtendedProfile) {
+          Object.keys(preferences.visibilityExtendedProfile).forEach((key) => {
+            visibilityExtendedProfile[key] = 'private';
+          });
+        }
         return {
           visibilityBio: 'private',
           visibilityCourseCertificates: 'private',
@@ -257,14 +264,22 @@ export const visibilitiesSelector = createSelector(
           visibilityLanguageProficiencies: 'private',
           visibilityName: 'private',
           visibilitySocialLinks: 'private',
-          visibilityExtendedProfile: 'private',
+          visibilityExtendedProfile,
         };
+      }
       case 'all_users':
-      default:
+      default: {
         // All users is intended to fall through to default.
         // If there is no value for accountPrivacy in perferences, that means it has not been
         // explicitly set yet. The server assumes - today - that this means "all_users",
         // so we emulate that here in the client.
+        const visibilityExtendedProfile = {};
+        if (preferences.visibilityExtendedProfile) {
+          Object.keys(preferences.visibilityExtendedProfile).forEach((key) => {
+            visibilityExtendedProfile[key] = 'all_users';
+          });
+        }
+
         return {
           visibilityBio: 'all_users',
           visibilityCourseCertificates: 'all_users',
@@ -273,8 +288,8 @@ export const visibilitiesSelector = createSelector(
           visibilityLanguageProficiencies: 'all_users',
           visibilityName: 'all_users',
           visibilitySocialLinks: 'all_users',
-          visibilityExtendedProfile: 'all_users',
-        };
+          visibilityExtendedProfile,
+        }; }
     }
   },
 );
@@ -393,6 +408,7 @@ export const profilePageSelector = createSelector(
     photoUploadError: errors.photo || null,
 
     // Extended profile fields
+    // Combine the field properties and its values
     extendedProfileFields: extendedProfileFields.map((field) => ({
       ...field,
       value: account.extendedProfile?.find(

--- a/src/profile/data/selectors.js
+++ b/src/profile/data/selectors.js
@@ -239,6 +239,7 @@ export const visibilitiesSelector = createSelector(
           visibilityLanguageProficiencies: preferences.visibilityLanguageProficiencies || 'all_users',
           visibilityName: preferences.visibilityName || 'all_users',
           visibilitySocialLinks: preferences.visibilitySocialLinks || 'all_users',
+          visibilityExtendedProfile: preferences.visibilityExtendedProfile || 'all_users',
         };
       case 'private':
         return {
@@ -249,6 +250,7 @@ export const visibilitiesSelector = createSelector(
           visibilityLanguageProficiencies: 'private',
           visibilityName: 'private',
           visibilitySocialLinks: 'private',
+          visibilityExtendedProfile: 'private',
         };
       case 'all_users':
       default:
@@ -264,6 +266,7 @@ export const visibilitiesSelector = createSelector(
           visibilityLanguageProficiencies: 'all_users',
           visibilityName: 'all_users',
           visibilitySocialLinks: 'all_users',
+          visibilityExtendedProfile: 'all_users',
         };
     }
   },
@@ -311,6 +314,10 @@ export const formValuesSelector = createSelector(
     visibilitySocialLinks: chooseFormValue(
       drafts.visibilitySocialLinks,
       visibilities.visibilitySocialLinks,
+    ),
+    visibilityExtendedProfile: chooseFormValue(
+      drafts.visibilityExtendedProfile,
+      visibilities.visibilityExtendedProfile,
     ),
   }),
 );

--- a/src/profile/data/selectors.js
+++ b/src/profile/data/selectors.js
@@ -11,6 +11,7 @@ export const formIdSelector = (state, props) => props.formId;
 export const userAccountSelector = state => state.userAccount;
 
 export const profileAccountSelector = state => state.profilePage.account;
+export const extendedProfileFieldsSelector = state => state.profilePage.extendedProfileFields;
 export const profileDraftsSelector = state => state.profilePage.drafts;
 export const accountPrivacySelector = state => state.profilePage.preferences.accountPrivacy;
 export const profilePreferencesSelector = state => state.profilePage.preferences;
@@ -323,6 +324,7 @@ export const profilePageSelector = createSelector(
   isLoadingProfileSelector,
   draftSocialLinksByPlatformSelector,
   accountErrorsSelector,
+  extendedProfileFieldsSelector,
   (
     account,
     formValues,
@@ -332,6 +334,7 @@ export const profilePageSelector = createSelector(
     isLoadingProfile,
     draftSocialLinksByPlatform,
     errors,
+    extendedProfileFields,
   ) => ({
     // Account data we need
     username: account.username,
@@ -374,5 +377,14 @@ export const profilePageSelector = createSelector(
     savePhotoState,
     isLoadingProfile,
     photoUploadError: errors.photo || null,
+
+    // Extended profile fields
+    extendedProfileFields: extendedProfileFields.map((field) => ({
+      ...field,
+      value: account.extendedProfile?.find(
+        (extendedProfileField) => extendedProfileField.fieldName === field.name,
+      )?.fieldValue,
+    })),
   }),
+
 );

--- a/src/profile/data/selectors.js
+++ b/src/profile/data/selectors.js
@@ -6,6 +6,7 @@ import {
   getCountryMessages,
   getLanguageMessages,
 } from '@edx/frontend-platform/i18n'; // eslint-disable-line
+import { moveCheckboxFieldsToEnd } from '../utils';
 
 export const formIdSelector = (state, props) => props.formId;
 export const userAccountSelector = state => state.userAccount;
@@ -414,7 +415,7 @@ export const profilePageSelector = createSelector(
       value: account.extendedProfile?.find(
         (extendedProfileField) => extendedProfileField.fieldName === field.name,
       )?.fieldValue,
-    })),
+    }))?.sort(moveCheckboxFieldsToEnd) ?? [],
   }),
 
 );

--- a/src/profile/data/services.js
+++ b/src/profile/data/services.js
@@ -89,7 +89,12 @@ export async function deleteProfilePhoto(username) {
 export async function getPreferences(username) {
   const { data } = await getHttpClient().get(`${getConfig().LMS_BASE_URL}/api/user/v1/preferences/${username}`);
 
-  return camelCaseObject(data);
+  const processedData = camelCaseObject(data);
+
+  return {
+    ...processedData,
+    visibilityExtendedProfile: JSON.parse(data['visibility.extended_profile']),
+  };
 }
 
 // PATCH PREFERENCES
@@ -105,7 +110,10 @@ export async function patchPreferences(username, params) {
     visibility_name: 'visibility.name',
     visibility_social_links: 'visibility.social_links',
     visibility_time_zone: 'visibility.time_zone',
+    visibility_extended_profile: 'visibility.extended_profile',
   });
+
+  processedParams['visibility.extended_profile'] = JSON.stringify(processedParams['visibility.extended_profile']);
 
   await getHttpClient().patch(`${getConfig().LMS_BASE_URL}/api/user/v1/preferences/${username}`, processedParams, {
     headers: { 'Content-Type': 'application/merge-patch+json' },

--- a/src/profile/data/services.js
+++ b/src/profile/data/services.js
@@ -1,5 +1,5 @@
 import { ensureConfig, getConfig } from '@edx/frontend-platform';
-import { getAuthenticatedHttpClient as getHttpClient } from '@edx/frontend-platform/auth';
+import { getAuthenticatedHttpClient, getAuthenticatedHttpClient as getHttpClient } from '@edx/frontend-platform/auth';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject, convertKeyNames, snakeCaseObject } from '../utils';
 
@@ -146,4 +146,27 @@ export async function getCourseCertificates(username) {
     logError(e);
     return [];
   }
+}
+
+export async function getExtendedProfileFields(urlParams) {
+  const requestConfig = {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    params: urlParams,
+    isPublic: true,
+  };
+
+  const { data } = await getAuthenticatedHttpClient()
+    .get(
+      `${getConfig().LMS_BASE_URL}/api/mfe_context`,
+      requestConfig,
+    )
+    .catch((e) => {
+      throw (e);
+    });
+
+  const extendedProfileFields = data.optionalFields.extended_profile
+    .map((fieldName) => (data.optionalFields.fields[fieldName] ?? data.registrationFields.fields[fieldName]))
+    .filter(Boolean);
+
+  return { fields: extendedProfileFields };
 }

--- a/src/profile/data/services.js
+++ b/src/profile/data/services.js
@@ -90,10 +90,11 @@ export async function getPreferences(username) {
   const { data } = await getHttpClient().get(`${getConfig().LMS_BASE_URL}/api/user/v1/preferences/${username}`);
 
   const processedData = camelCaseObject(data);
+  const visibilityExtendedProfile = Object.prototype.hasOwnProperty.call(data, 'visibilityExtendedProfile');
 
   return {
     ...processedData,
-    visibilityExtendedProfile: JSON.parse(data['visibility.extended_profile']),
+    visibilityExtendedProfile: visibilityExtendedProfile ? JSON.parse(data['visibility.extended_profile']) : {},
   };
 }
 

--- a/src/profile/data/services.js
+++ b/src/profile/data/services.js
@@ -174,7 +174,7 @@ export async function getExtendedProfileFields(urlParams) {
     });
 
   const extendedProfileFields = data.optionalFields.extended_profile
-    .map((fieldName) => (data.optionalFields.fields[fieldName] ?? data.registrationFields.fields[fieldName]))
+    .map((fieldName) => (data.registrationFields.fields[fieldName]))
     .filter(Boolean);
 
   return { fields: extendedProfileFields };

--- a/src/profile/data/services.js
+++ b/src/profile/data/services.js
@@ -157,25 +157,16 @@ export async function getCourseCertificates(username) {
   }
 }
 
-export async function getExtendedProfileFields(urlParams) {
-  const requestConfig = {
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    params: urlParams,
-    isPublic: true,
-  };
+export async function getExtendedProfileFields() {
+  const url = `${getConfig().LMS_BASE_URL}/user_api/v1/account/registration/`;
 
   const { data } = await getAuthenticatedHttpClient()
     .get(
-      `${getConfig().LMS_BASE_URL}/api/mfe_context`,
-      requestConfig,
+      url,
     )
     .catch((e) => {
       throw (e);
     });
 
-  const extendedProfileFields = data.optionalFields.extended_profile
-    .map((fieldName) => (data.registrationFields.fields[fieldName]))
-    .filter(Boolean);
-
-  return { fields: extendedProfileFields };
+  return { fields: data.fields };
 }

--- a/src/profile/forms/ExtendedProfileFields.jsx
+++ b/src/profile/forms/ExtendedProfileFields.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import get from 'lodash.get';
+
+// Mock Data
+import mockData from '../data/mock_data';
+
+// Components
+import EditableItemHeader from './elements/EditableItemHeader';
+import SwitchContent from './elements/SwitchContent';
+import SelectField from './elements/SelectField';
+import { editableFormSelector } from '../data/selectors';
+import TextField from './elements/TextField';
+
+const ExtendedProfileFields = (props) => {
+  const {
+    extendedProfileFields, formId, changeHandler, submitHandler, closeHandler, openHandler, editMode,
+  } = props;
+
+  //   if (!learningGoal) {
+  //     learningGoal = mockData.learningGoal;
+  //   }
+
+  //   if (!editMode || editMode === 'empty') { // editMode defaults to 'empty', not sure why yet
+  //     editMode = mockData.editMode;
+  //   }
+
+  //   if (!visibilityLearningGoal) {
+  //     visibilityLearningGoal = mockData.visibilityLearningGoal;
+  //   }
+
+  return extendedProfileFields?.map((field) => (
+    <SwitchContent
+      className="mb-5"
+      expression={field.type}
+      cases={{
+        checkbox: (
+          <>
+            <EditableItemHeader content={field.label} />
+            <p data-hj-suppress className="lead">
+              {field.default}
+            </p>
+          </>
+        ),
+        text: (
+          <TextField
+            formId={formId}
+            changeHandler={changeHandler}
+            submitHandler={submitHandler}
+            closeHandler={closeHandler}
+            openHandler={openHandler}
+            editMode={editMode}
+            {...field}
+          />
+        ),
+        select: (
+          <SelectField
+            formId={formId}
+            changeHandler={changeHandler}
+            submitHandler={submitHandler}
+            closeHandler={closeHandler}
+            openHandler={openHandler}
+            editMode={editMode}
+            {...field}
+          />
+        ),
+      }}
+    />
+  ));
+};
+
+ExtendedProfileFields.propTypes = {
+  // From Selector
+  formId: PropTypes.string.isRequired,
+  extendedProfileFields: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    default: PropTypes.unknown,
+    placeholder: PropTypes.string,
+    instructions: PropTypes.string,
+    options: PropTypes.arrayOf(PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    })),
+    error_message: PropTypes.shape({
+      required: PropTypes.string,
+      invalid: PropTypes.string,
+    }),
+    restrictions: PropTypes.shape({
+      max_length: PropTypes.number,
+    }),
+    type: PropTypes.string.isRequired,
+  })).isRequired,
+
+  // Actions
+  changeHandler: PropTypes.func.isRequired,
+  submitHandler: PropTypes.func.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+  openHandler: PropTypes.func.isRequired,
+
+  // i18n
+  intl: intlShape.isRequired,
+};
+
+ExtendedProfileFields.defaultProps = {
+};
+
+export default connect(editableFormSelector, {})(injectIntl(ExtendedProfileFields));

--- a/src/profile/forms/ExtendedProfileFields.jsx
+++ b/src/profile/forms/ExtendedProfileFields.jsx
@@ -117,3 +117,5 @@ ExtendedProfileFields.defaultProps = {
 };
 
 export default ExtendedProfileFields;
+
+export const TestableExtendedProfileFields = ExtendedProfileFields;

--- a/src/profile/forms/ExtendedProfileFields.jsx
+++ b/src/profile/forms/ExtendedProfileFields.jsx
@@ -41,7 +41,7 @@ const ExtendedProfileFields = (props) => {
   };
 
   return (
-    <div className="">
+    <div>
       {extendedProfileFields.sort(moveCheckboxFieldsToEnd)?.map((field) => {
         const value = draftProfile?.extendedProfile?.find(
           (extendedField) => extendedField.fieldName === field.name,

--- a/src/profile/forms/ExtendedProfileFields.jsx
+++ b/src/profile/forms/ExtendedProfileFields.jsx
@@ -52,6 +52,7 @@ const ExtendedProfileFields = (props) => {
 
         const commonProps = {
           ...field,
+          errorMessage: field.error_message,
           formId: `${formId}/${field.name}`,
           changeHandler: handleChangeExtendedField,
           submitHandler: handleSubmitExtendedField,
@@ -92,10 +93,10 @@ ExtendedProfileFields.propTypes = {
     })),
     error_message: PropTypes.shape({
       required: PropTypes.string,
-      invalid: PropTypes.string,
     }),
     restrictions: PropTypes.shape({
       max_length: PropTypes.number,
+      min_length: PropTypes.number,
     }),
     type: PropTypes.string.isRequired,
   })).isRequired,

--- a/src/profile/forms/ExtendedProfileFields.jsx
+++ b/src/profile/forms/ExtendedProfileFields.jsx
@@ -66,15 +66,9 @@ const ExtendedProfileFields = (props) => {
             className="mb-5"
             expression={field.type}
             cases={{
-              checkbox: (
-                <CheckboxField {...commonProps} />
-              ),
-              text: (
-                <TextField {...commonProps} />
-              ),
-              select: (
-                <SelectField {...commonProps} />
-              ),
+              checkbox: <CheckboxField {...commonProps} />,
+              text: <TextField {...commonProps} />,
+              select: <SelectField {...commonProps} />,
             }}
           />
         );

--- a/src/profile/forms/ExtendedProfileFields.jsx
+++ b/src/profile/forms/ExtendedProfileFields.jsx
@@ -8,7 +8,6 @@ import SwitchContent from './elements/SwitchContent';
 import SelectField from './elements/SelectField';
 import TextField from './elements/TextField';
 import CheckboxField from './elements/CheckboxField';
-import { moveCheckboxFieldsToEnd } from '../utils';
 
 const ExtendedProfileFields = (props) => {
   const {
@@ -42,7 +41,7 @@ const ExtendedProfileFields = (props) => {
 
   return (
     <div>
-      {extendedProfileFields.sort(moveCheckboxFieldsToEnd)?.map((field) => {
+      {extendedProfileFields?.map((field) => {
         const value = draftProfile?.extendedProfile?.find(
           (extendedField) => extendedField.fieldName === field.name,
         )?.fieldValue ?? field.value;
@@ -52,7 +51,7 @@ const ExtendedProfileFields = (props) => {
 
         const commonProps = {
           ...field,
-          errorMessage: field.error_message,
+          errorMessage: field.errorMessage,
           formId: `${formId}/${field.name}`,
           changeHandler: handleChangeExtendedField,
           submitHandler: handleSubmitExtendedField,
@@ -91,7 +90,7 @@ ExtendedProfileFields.propTypes = {
       value: PropTypes.string.isRequired,
       label: PropTypes.string.isRequired,
     })),
-    error_message: PropTypes.shape({
+    errorMessage: PropTypes.shape({
       required: PropTypes.string,
     }),
     restrictions: PropTypes.shape({

--- a/src/profile/forms/ExtendedProfileFields.test.jsx
+++ b/src/profile/forms/ExtendedProfileFields.test.jsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import {
+  render, screen, fireEvent,
+} from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+
+import { TestableExtendedProfileFields as ExtendedProfileFields } from './ExtendedProfileFields';
+
+jest.mock('./elements/SelectField', () => jest.fn((props) => (
+  <form onSubmit={props.submitHandler} data-testid="test-form">
+    <select data-testid="select-field" aria-label={props.label} value={props.value} onChange={(e) => props.changeHandler(props.formId, e.target.value)}>
+      {props.options.map((option) => (
+        <option key={option.value} value={option.value}>{option.label}</option>
+      ))}
+    </select>
+  </form>
+)));
+jest.mock('./elements/TextField', () => jest.fn((props) => (
+  <form onSubmit={props.submitHandler} data-testid="test-form">
+    <input data-testid="text-field" type="text" aria-label={props.label} value={props.value} onChange={(e) => props.changeHandler(props.formId, e.target.value)} />
+  </form>
+)));
+jest.mock('./elements/CheckboxField', () => jest.fn((props) => (
+  <form onSubmit={props.submitHandler} data-testid="test-form">
+    <input data-testid="checkbox-field" type="checkbox" aria-label={props.label} checked={props.value} onChange={(e) => props.changeHandler(props.formId, e.target.checked)} />
+  </form>
+)));
+
+const mockStore = configureStore([]);
+
+describe('ExtendedProfileFields', () => {
+  const store = mockStore({
+    profilePage: {
+      drafts: {},
+      account: {
+        extendedProfile: [
+          { fieldName: 'first_name', fieldValue: 'John' },
+        ],
+      },
+      preferences: { visibilityExtendedProfile: {} },
+    },
+  });
+
+  const renderComponent = (fields, props = {}) => {
+    render(
+      <Provider store={store}>
+        <IntlProvider locale="en">
+          <ExtendedProfileFields
+            formId="test-form"
+            extendedProfileFields={fields}
+            changeHandler={jest.fn()}
+            submitHandler={jest.fn()}
+            closeHandler={jest.fn()}
+            openHandler={jest.fn()}
+            isAuthenticatedUserProfile
+            intl={{ formatMessage: jest.fn(() => 'Empty field') }}
+            {...props}
+          />
+        </IntlProvider>
+      </Provider>,
+    );
+  };
+
+  it('renders SelectField when field type is select', () => {
+    renderComponent([
+      {
+        name: 'country', type: 'select', label: 'Country', value: '', options: [{ value: 'us', label: 'USA' }],
+      },
+    ]);
+    expect(screen.getByTestId('select-field')).toBeInTheDocument();
+  });
+
+  it('renders TextField when field type is text', () => {
+    renderComponent([
+      {
+        name: 'first_name', type: 'text', label: 'First Name', value: 'John',
+      },
+    ]);
+    expect(screen.getByTestId('text-field')).toBeInTheDocument();
+  });
+
+  it('renders CheckboxField when field type is checkbox', () => {
+    renderComponent([
+      {
+        name: 'newsletter', type: 'checkbox', label: 'Subscribe', value: false,
+      },
+    ]);
+    expect(screen.getByTestId('checkbox-field')).toBeInTheDocument();
+  });
+
+  it('handles change events', () => {
+    const changeHandler = jest.fn();
+    renderComponent([
+      {
+        name: 'first_name', type: 'text', label: 'First Name', value: 'John',
+      },
+    ], { changeHandler });
+
+    const newValue = 'new value';
+    const textField = screen.getByLabelText('First Name');
+    fireEvent.change(textField, { target: { value: newValue } });
+    store.getState().profilePage.account.extendedProfile[0].fieldValue = newValue;
+    expect(changeHandler).toHaveBeenCalledWith('test-form', store.getState().profilePage.account.extendedProfile);
+  });
+
+  it('handles form submission', () => {
+    const submitHandler = jest.fn();
+    renderComponent([
+      {
+        name: 'first_name', type: 'text', label: 'First Name', value: 'John',
+      },
+    ], { submitHandler });
+
+    const form = screen.getByTestId('test-form');
+    fireEvent.submit(form);
+    expect(submitHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/profile/forms/elements/CheckboxField.jsx
+++ b/src/profile/forms/elements/CheckboxField.jsx
@@ -52,7 +52,7 @@ const CheckboxField = ({
       cases={{
         editing: (
           <div role="dialog" aria-labelledby={`${formId}-label`}>
-            <form onSubmit={handleSubmit}>
+            <form data-testid="test-form" onSubmit={handleSubmit}>
               <Form.Group
                 controlId={formId}
                 isInvalid={error !== null}
@@ -162,3 +162,5 @@ CheckboxField.defaultProps = {
 };
 
 export default connect(editableFormSelector, {})(CheckboxField);
+
+export const TestableCheckboxField = CheckboxField;

--- a/src/profile/forms/elements/CheckboxField.jsx
+++ b/src/profile/forms/elements/CheckboxField.jsx
@@ -1,16 +1,19 @@
+/* eslint-disable react/no-danger */
 import React from 'react';
+import DOMPurify from 'dompurify';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Form } from '@openedx/paragon';
+
+import { editableFormSelector } from '../../data/selectors';
 
 // Components
-import { Form } from '@openedx/paragon';
-import { connect } from 'react-redux';
 import FormControls from './FormControls';
 import EditableItemHeader from './EditableItemHeader';
 import EmptyContent from './EmptyContent';
 import SwitchContent from './SwitchContent';
-import { editableFormSelector } from '../../data/selectors';
 
-const TextField = ({
+const CheckboxField = ({
   formId,
   value,
   visibility,
@@ -26,7 +29,7 @@ const TextField = ({
   openHandler,
 }) => {
   const handleChange = (e) => {
-    const { name, value: newValue } = e.target;
+    const { name, checked: newValue } = e.target;
     changeHandler(name, newValue);
   };
 
@@ -54,16 +57,14 @@ const TextField = ({
                 controlId={formId}
                 isInvalid={error !== null}
               >
-                <label className="edit-section-header" htmlFor={formId}>
-                  {label}
-                </label>
-                <input
-                  className="form-control"
+                <Form.Checkbox
                   id={formId}
                   name={formId}
-                  value={value}
+                  checked={value}
                   onChange={handleChange}
-                />
+                >
+                  <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(label) }} />
+                </Form.Checkbox>
                 {error !== null && (
                 <Form.Control.Feedback hasIcon={false}>
                   {error}
@@ -84,10 +85,18 @@ const TextField = ({
         editable: (
           <>
             <EditableItemHeader
-              content={label}
+              content={(
+                <Form.Checkbox
+                  id={formId}
+                  name={formId}
+                  checked={value}
+                >
+                  <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(label) }} />
+                </Form.Checkbox>
+              )}
               showEditButton
               onClickEdit={handleOpen}
-              showVisibility={visibility !== null}
+              showVisibility={false}
               visibility={visibility}
             />
             <p data-hj-suppress className="h5">{value}</p>
@@ -115,9 +124,9 @@ const TextField = ({
   );
 };
 
-TextField.propTypes = {
+CheckboxField.propTypes = {
   formId: PropTypes.string.isRequired,
-  value: PropTypes.string,
+  value: PropTypes.bool,
   visibility: PropTypes.oneOf(['private', 'all_users']),
   editMode: PropTypes.oneOf(['editing', 'editable', 'empty', 'static']),
   saveState: PropTypes.string,
@@ -131,14 +140,14 @@ TextField.propTypes = {
   openHandler: PropTypes.func.isRequired,
 };
 
-TextField.defaultProps = {
+CheckboxField.defaultProps = {
   editMode: 'static',
   saveState: null,
-  value: null,
+  value: false,
   placeholder: '',
   instructions: '',
   visibility: 'private',
   error: null,
 };
 
-export default connect(editableFormSelector, {})(TextField);
+export default connect(editableFormSelector, {})(CheckboxField);

--- a/src/profile/forms/elements/CheckboxField.jsx
+++ b/src/profile/forms/elements/CheckboxField.jsx
@@ -113,9 +113,20 @@ const CheckboxField = ({
             </small>
           </>
         ),
-        static: (
+        static: value && (
           <>
-            <EditableItemHeader content={label} />
+            <EditableItemHeader
+              content={(
+                <Form.Checkbox
+                  id={formId}
+                  name={formId}
+                  checked={value}
+                >
+                  <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(label) }} />
+                </Form.Checkbox>
+              )}
+              showVisibility={false}
+            />
             <p data-hj-suppress className="h5">{value}</p>
           </>
         ),

--- a/src/profile/forms/elements/CheckboxField.test.jsx
+++ b/src/profile/forms/elements/CheckboxField.test.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import {
+  render, screen, fireEvent,
+} from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { TestableCheckboxField } from './CheckboxField';
+
+const mockStore = configureStore([]);
+
+describe('CheckboxField', () => {
+  const defaultProps = {
+    formId: 'test-checkbox',
+    value: false,
+    visibility: 'private',
+    editMode: 'editing',
+    saveState: null,
+    error: null,
+    label: 'Accept Terms',
+    placeholder: 'Please accept',
+    instructions: 'Check the box to continue',
+    changeHandler: jest.fn(),
+    submitHandler: jest.fn(),
+    closeHandler: jest.fn(),
+    openHandler: jest.fn(),
+  };
+
+  let store;
+
+  beforeEach(() => {
+    store = mockStore({});
+  });
+
+  const renderComponent = (props = {}) => {
+    render(
+      <Provider store={store}>
+        <IntlProvider locale="en">
+          <TestableCheckboxField {...defaultProps} {...props} />
+        </IntlProvider>
+      </Provider>,
+    );
+  };
+
+  it('renders checkbox in editing mode', () => {
+    renderComponent();
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  it('calls changeHandler when checkbox is clicked', () => {
+    renderComponent();
+    const checkbox = screen.getByRole('checkbox');
+    fireEvent.click(checkbox);
+    expect(defaultProps.changeHandler).toHaveBeenCalledWith('test-checkbox', true);
+  });
+
+  it('calls submitHandler when form is submitted', () => {
+    renderComponent();
+    const form = screen.getByTestId('test-form');
+    fireEvent.submit(form);
+    expect(defaultProps.submitHandler).toHaveBeenCalledWith('test-checkbox');
+  });
+
+  it('calls closeHandler when form is closed', () => {
+    renderComponent();
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(defaultProps.closeHandler).toHaveBeenCalledWith('test-checkbox');
+  });
+
+  it('renders empty state when in empty mode', () => {
+    renderComponent({ editMode: 'empty' });
+    expect(screen.getByText('Check the box to continue')).toBeInTheDocument();
+  });
+
+  it('renders static mode with checked value', () => {
+    renderComponent({ editMode: 'static', value: true });
+    expect(screen.getByLabelText('Accept Terms')).toBeChecked();
+  });
+
+  it('renders editable mode with edit button', () => {
+    renderComponent({ editMode: 'editable' });
+    expect(screen.getByText('Accept Terms')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it('calls openHandler when edit button is clicked', () => {
+    renderComponent({ editMode: 'editable' });
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    expect(defaultProps.openHandler).toHaveBeenCalledWith('test-checkbox');
+  });
+});

--- a/src/profile/forms/elements/FormControls.jsx
+++ b/src/profile/forms/elements/FormControls.jsx
@@ -8,7 +8,7 @@ import messages from './FormControls.messages';
 import { VisibilitySelect } from './Visibility';
 
 const FormControls = ({
-  cancelHandler, changeHandler, visibility, visibilityId, saveState, intl, showVisibilitySelect,
+  cancelHandler, changeHandler, visibility, visibilityId, saveState, intl, showVisibilitySelect, disabled,
 }) => {
   // Eliminate error/failed state for save button
   const buttonState = saveState === 'error' ? null : saveState;
@@ -52,6 +52,7 @@ const FormControls = ({
             }
           }}
           disabledStates={[]}
+          disabled={disabled}
         />
         <Button variant="link" onClick={cancelHandler}>
           {intl.formatMessage(messages['profile.formcontrols.button.cancel'])}
@@ -70,6 +71,7 @@ FormControls.propTypes = {
   cancelHandler: PropTypes.func.isRequired,
   changeHandler: PropTypes.func.isRequired,
   showVisibilitySelect: PropTypes.bool,
+  disabled: PropTypes.bool,
 
   // i18n
   intl: intlShape.isRequired,
@@ -79,4 +81,5 @@ FormControls.defaultProps = {
   visibility: 'private',
   saveState: null,
   showVisibilitySelect: true,
+  disabled: false,
 };

--- a/src/profile/forms/elements/FormControls.jsx
+++ b/src/profile/forms/elements/FormControls.jsx
@@ -8,13 +8,14 @@ import messages from './FormControls.messages';
 import { VisibilitySelect } from './Visibility';
 
 const FormControls = ({
-  cancelHandler, changeHandler, visibility, visibilityId, saveState, intl,
+  cancelHandler, changeHandler, visibility, visibilityId, saveState, intl, showVisibilitySelect,
 }) => {
   // Eliminate error/failed state for save button
   const buttonState = saveState === 'error' ? null : saveState;
 
   return (
     <div className="d-flex flex-row-reverse flex-wrap justify-content-end align-items-center">
+      {showVisibilitySelect && (
       <div className="form-group d-flex flex-wrap">
         <label className="col-form-label" htmlFor={visibilityId}>
           {intl.formatMessage(messages['profile.formcontrols.who.can.see'])}
@@ -28,6 +29,7 @@ const FormControls = ({
           onChange={changeHandler}
         />
       </div>
+      )}
       <div className="form-group flex-shrink-0 flex-grow-1">
         <StatefulButton
           type="submit"
@@ -67,6 +69,7 @@ FormControls.propTypes = {
   visibilityId: PropTypes.string.isRequired,
   cancelHandler: PropTypes.func.isRequired,
   changeHandler: PropTypes.func.isRequired,
+  showVisibilitySelect: PropTypes.bool,
 
   // i18n
   intl: intlShape.isRequired,
@@ -75,4 +78,5 @@ FormControls.propTypes = {
 FormControls.defaultProps = {
   visibility: 'private',
   saveState: null,
+  showVisibilitySelect: true,
 };

--- a/src/profile/forms/elements/SelectField.jsx
+++ b/src/profile/forms/elements/SelectField.jsx
@@ -2,11 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Form } from '@openedx/paragon';
 
+import { connect } from 'react-redux';
 import FormControls from './FormControls';
 import EditableItemHeader from './EditableItemHeader';
 import EmptyContent from './EmptyContent';
 import SwitchContent from './SwitchContent';
-import { capitalizeFirstLetter } from '../../utils';
+import { editableFormSelector } from '../../data/selectors';
 
 const SelectField = ({
   formId,
@@ -43,7 +44,6 @@ const SelectField = ({
 
   return (
     <SwitchContent
-      className="mb-5"
       expression={editMode}
       cases={{
         editing: (
@@ -77,9 +77,10 @@ const SelectField = ({
                 )}
               </Form.Group>
               <FormControls
-                visibilityId={`visibility${capitalizeFirstLetter(formId)}`}
+                // TODO: Modify api/user/v1/accounts/{username} so it returns extended_profile_fields for no owners
+                // visibilityId={`visibility${capitalizeFirstLetter(formId)}`}
+                showVisibilitySelect={false}
                 saveState={saveState}
-                visibility={visibility}
                 cancelHandler={handleClose}
                 changeHandler={handleChange}
               />
@@ -149,4 +150,4 @@ SelectField.defaultProps = {
   error: null,
 };
 
-export default SelectField;
+export default connect(editableFormSelector, {})(SelectField);

--- a/src/profile/forms/elements/SelectField.jsx
+++ b/src/profile/forms/elements/SelectField.jsx
@@ -6,6 +6,7 @@ import FormControls from './FormControls';
 import EditableItemHeader from './EditableItemHeader';
 import EmptyContent from './EmptyContent';
 import SwitchContent from './SwitchContent';
+import { capitalizeFirstLetter } from '../../utils';
 
 const SelectField = ({
   formId,
@@ -76,7 +77,7 @@ const SelectField = ({
                 )}
               </Form.Group>
               <FormControls
-                visibilityId={`visibility${formId}`}
+                visibilityId={`visibility${capitalizeFirstLetter(formId)}`}
                 saveState={saveState}
                 visibility={visibility}
                 cancelHandler={handleClose}
@@ -131,7 +132,7 @@ SelectField.propTypes = {
     code: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
   })).isRequired,
-  fieldMessages: PropTypes.objectOf(PropTypes.string).isRequired,
+  //   fieldMessages: PropTypes.objectOf(PropTypes.string).isRequired,
   label: PropTypes.string.isRequired,
   emptyMessage: PropTypes.string.isRequired,
   changeHandler: PropTypes.func.isRequired,

--- a/src/profile/forms/elements/SelectField.jsx
+++ b/src/profile/forms/elements/SelectField.jsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Form } from '@openedx/paragon';
+
+import FormControls from './FormControls';
+import EditableItemHeader from './EditableItemHeader';
+import EmptyContent from './EmptyContent';
+import SwitchContent from './SwitchContent';
+
+const SelectField = ({
+  formId,
+  value,
+  visibility,
+  editMode,
+  saveState,
+  error,
+  options,
+  label,
+  emptyMessage,
+  changeHandler,
+  submitHandler,
+  closeHandler,
+  openHandler,
+}) => {
+  const handleChange = (e) => {
+    const { name, value: newValue } = e.target;
+    changeHandler(name, newValue);
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    submitHandler(formId);
+  };
+
+  const handleClose = () => {
+    closeHandler(formId);
+  };
+
+  const handleOpen = () => {
+    openHandler(formId);
+  };
+
+  return (
+    <SwitchContent
+      className="mb-5"
+      expression={editMode}
+      cases={{
+        editing: (
+          <div role="dialog" aria-labelledby={`${formId}-label`}>
+            <form onSubmit={handleSubmit}>
+              <Form.Group
+                controlId={formId}
+                isInvalid={error !== null}
+              >
+                <label className="edit-section-header" htmlFor={formId}>
+                  {label}
+                </label>
+                <select
+                  data-hj-suppress
+                  className="form-control"
+                  type="select"
+                  id={formId}
+                  name={formId}
+                  value={value}
+                  onChange={handleChange}
+                >
+                  <option value="">&nbsp;</option>
+                  {options.map(([code, name]) => (
+                    <option key={code} value={code}>{name}</option>
+                  ))}
+                </select>
+                {error !== null && (
+                  <Form.Control.Feedback hasIcon={false}>
+                    {error}
+                  </Form.Control.Feedback>
+                )}
+              </Form.Group>
+              <FormControls
+                visibilityId={`visibility${formId}`}
+                saveState={saveState}
+                visibility={visibility}
+                cancelHandler={handleClose}
+                changeHandler={handleChange}
+              />
+            </form>
+          </div>
+        ),
+        editable: (
+          <>
+            <EditableItemHeader
+              content={label}
+              showEditButton
+              onClickEdit={handleOpen}
+              showVisibility={visibility !== null}
+              visibility={visibility}
+            />
+            <p data-hj-suppress className="h5">{value}</p>
+          </>
+        ),
+        empty: (
+          <>
+            <EditableItemHeader
+              content={label}
+            />
+            <EmptyContent onClick={handleOpen}>
+              {emptyMessage}
+            </EmptyContent>
+          </>
+        ),
+        static: (
+          <>
+            <EditableItemHeader
+              content={label}
+            />
+            <p data-hj-suppress className="h5">{value}</p>
+          </>
+        ),
+      }}
+    />
+  );
+};
+
+SelectField.propTypes = {
+  formId: PropTypes.string.isRequired,
+  value: PropTypes.string,
+  visibility: PropTypes.oneOf(['private', 'all_users']),
+  editMode: PropTypes.oneOf(['editing', 'editable', 'empty', 'static']),
+  saveState: PropTypes.string,
+  error: PropTypes.string,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    code: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  })).isRequired,
+  fieldMessages: PropTypes.objectOf(PropTypes.string).isRequired,
+  label: PropTypes.string.isRequired,
+  emptyMessage: PropTypes.string.isRequired,
+  changeHandler: PropTypes.func.isRequired,
+  submitHandler: PropTypes.func.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+  openHandler: PropTypes.func.isRequired,
+};
+
+SelectField.defaultProps = {
+  editMode: 'static',
+  saveState: null,
+  value: null,
+  visibility: 'private',
+  error: null,
+};
+
+export default SelectField;

--- a/src/profile/forms/elements/SelectField.jsx
+++ b/src/profile/forms/elements/SelectField.jsx
@@ -66,8 +66,8 @@ const SelectField = ({
                   onChange={handleChange}
                 >
                   <option value="">&nbsp;</option>
-                  {options.map(([code, name]) => (
-                    <option key={code} value={code}>{name}</option>
+                  {options?.map(({ name, value: optionValue }) => (
+                    <option key={optionValue} value={optionValue}>{name}</option>
                   ))}
                 </select>
                 {error !== null && (
@@ -130,10 +130,9 @@ SelectField.propTypes = {
   saveState: PropTypes.string,
   error: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.shape({
-    code: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
   })).isRequired,
-  //   fieldMessages: PropTypes.objectOf(PropTypes.string).isRequired,
   label: PropTypes.string.isRequired,
   emptyMessage: PropTypes.string.isRequired,
   changeHandler: PropTypes.func.isRequired,

--- a/src/profile/forms/elements/SelectField.jsx
+++ b/src/profile/forms/elements/SelectField.jsx
@@ -109,7 +109,7 @@ const SelectField = ({
             </EmptyContent>
           </>
         ),
-        static: (
+        static: value && (
           <>
             <EditableItemHeader
               content={label}

--- a/src/profile/forms/elements/SelectField.jsx
+++ b/src/profile/forms/elements/SelectField.jsx
@@ -48,7 +48,7 @@ const SelectField = ({
       cases={{
         editing: (
           <div role="dialog" aria-labelledby={`${formId}-label`}>
-            <form onSubmit={handleSubmit}>
+            <form data-testid="test-form" onSubmit={handleSubmit}>
               <Form.Group
                 controlId={formId}
                 isInvalid={error !== null}
@@ -151,3 +151,5 @@ SelectField.defaultProps = {
 };
 
 export default connect(editableFormSelector, {})(SelectField);
+
+export const TestableSelectField = SelectField;

--- a/src/profile/forms/elements/SelectField.test.jsx
+++ b/src/profile/forms/elements/SelectField.test.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { TestableSelectField } from './SelectField';
+
+const mockStore = configureStore([]);
+
+describe('SelectField', () => {
+  const defaultProps = {
+    formId: 'test-select',
+    value: '',
+    visibility: 'private',
+    editMode: 'editing',
+    saveState: null,
+    error: null,
+    options: [
+      ['us', 'United States'],
+      ['ca', 'Canada'],
+      ['uk', 'United Kingdom'],
+    ],
+    label: 'Country',
+    emptyMessage: 'No country selected',
+    changeHandler: jest.fn(),
+    submitHandler: jest.fn(),
+    closeHandler: jest.fn(),
+    openHandler: jest.fn(),
+  };
+
+  let store;
+
+  beforeEach(() => {
+    store = mockStore({});
+  });
+
+  const renderComponent = (props = {}) => {
+    render(
+      <Provider store={store}>
+        <IntlProvider locale="en">
+          <TestableSelectField {...defaultProps} {...props} />
+        </IntlProvider>
+      </Provider>,
+    );
+  };
+
+  it('renders select field in editing mode', () => {
+    renderComponent();
+    expect(screen.getByLabelText('Country')).toBeInTheDocument();
+  });
+
+  it('calls changeHandler when an option is selected', () => {
+    renderComponent();
+    const select = screen.getByLabelText('Country');
+    fireEvent.change(select, { target: { value: 'ca' } });
+    expect(defaultProps.changeHandler).toHaveBeenCalledWith('test-select', 'ca');
+  });
+
+  it('calls submitHandler when form is submitted', () => {
+    renderComponent();
+    const form = screen.getByTestId('test-form');
+    fireEvent.submit(form);
+    expect(defaultProps.submitHandler).toHaveBeenCalledWith('test-select');
+  });
+
+  it('calls closeHandler when form is closed', () => {
+    renderComponent();
+    defaultProps.closeHandler.mockClear();
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(defaultProps.closeHandler).toHaveBeenCalledWith('test-select');
+  });
+
+  it('renders empty state when in empty mode', () => {
+    renderComponent({ editMode: 'empty' });
+    expect(screen.getByText('No country selected')).toBeInTheDocument();
+  });
+
+  it('renders static mode with selected value', () => {
+    renderComponent({ editMode: 'static', value: 'United States' });
+    expect(screen.getByText('United States')).toBeInTheDocument();
+  });
+
+  it('renders editable mode with edit button', () => {
+    renderComponent({ editMode: 'editable' });
+    expect(screen.getByText('Country')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it('calls openHandler when edit button is clicked', () => {
+    renderComponent({ editMode: 'editable' });
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    expect(defaultProps.openHandler).toHaveBeenCalledWith('test-select');
+  });
+});

--- a/src/profile/forms/elements/SelectField.test.jsx
+++ b/src/profile/forms/elements/SelectField.test.jsx
@@ -16,9 +16,9 @@ describe('SelectField', () => {
     saveState: null,
     error: null,
     options: [
-      ['us', 'United States'],
-      ['ca', 'Canada'],
-      ['uk', 'United Kingdom'],
+      { value: 'ca', name: 'Canada' },
+      { value: 'us', name: 'United States' },
+      { value: 'mx', name: 'Mexico' },
     ],
     label: 'Country',
     emptyMessage: 'No country selected',

--- a/src/profile/forms/elements/TextField.jsx
+++ b/src/profile/forms/elements/TextField.jsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+// Components
+import { Form } from '@openedx/paragon';
+import FormControls from './FormControls';
+import EditableItemHeader from './EditableItemHeader';
+import EmptyContent from './EmptyContent';
+import SwitchContent from './SwitchContent';
+
+// Selectors
+import { editableFormSelector } from '../../data/selectors';
+
+const TextField = ({
+  formId,
+  value,
+  visibility,
+  editMode,
+  saveState,
+  error,
+  options,
+  label,
+  emptyMessage,
+  fieldMessages,
+  placeholder,
+  instructions,
+  changeHandler,
+  submitHandler,
+  closeHandler,
+  openHandler,
+}) => {
+  const handleChange = (e) => {
+    const { name: selected, value: newValue } = e.target;
+    changeHandler(selected, newValue);
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    submitHandler(formId);
+  };
+
+  const handleClose = () => {
+    closeHandler(formId);
+  };
+
+  const handleOpen = () => {
+    openHandler(formId);
+  };
+
+  return (
+    <SwitchContent
+      className="mb-5"
+      expression={editMode}
+      cases={{
+        editing: (
+          <div role="dialog" aria-labelledby={`${formId}-label`}>
+            <form onSubmit={handleSubmit}>
+              <Form.Group
+                controlId={formId}
+                isInvalid={error !== null}
+              >
+                <label className="edit-section-header" htmlFor={formId}>
+                  {label}
+                </label>
+                <input
+                  className="form-control"
+                  id={formId}
+                  name={formId}
+                  value={value}
+                  onChange={handleChange}
+                />
+                {error !== null && (
+                <Form.Control.Feedback hasIcon={false}>
+                  {error}
+                </Form.Control.Feedback>
+                )}
+              </Form.Group>
+              <FormControls
+                saveState={saveState}
+                // visibility={visibilityBio}
+                cancelHandler={handleClose}
+                changeHandler={handleChange}
+              />
+            </form>
+          </div>
+        ),
+        editable: (
+          <>
+            <EditableItemHeader
+              content={label}
+              showEditButton
+              onClickEdit={handleOpen}
+              showVisibility={visibility !== null}
+              visibility={visibility}
+            />
+            <p data-hj-suppress className="h5">{value}</p>
+          </>
+        ),
+        // empty: (
+        //   <>
+        //     <EditableItemHeader content={intl.formatMessage(messages['profile.name.full.name'])} />
+        //     <EmptyContent onClick={handleOpen}>
+        //       {intl.formatMessage(messages['profile.name.empty'])}
+        //     </EmptyContent>
+        //     <small className="form-text text-muted">
+        //       {intl.formatMessage(messages['profile.name.details'])}
+        //     </small>
+        //   </>
+        // ),
+        // static: (
+        //   <>
+        //     <EditableItemHeader content={intl.formatMessage(messages['profile.name.full.name'])} />
+        //     <p data-hj-suppress className="h5">{name}</p>
+        //   </>
+        // ),
+      }}
+    />
+  );
+};
+
+TextField.propTypes = {
+  formId: PropTypes.string.isRequired,
+  value: PropTypes.string,
+  visibility: PropTypes.oneOf(['private', 'all_users']),
+  editMode: PropTypes.oneOf(['editing', 'editable', 'empty', 'static']),
+  saveState: PropTypes.string,
+  error: PropTypes.string,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    code: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  })).isRequired,
+  fieldMessages: PropTypes.objectOf(PropTypes.string).isRequired,
+  label: PropTypes.string.isRequired,
+  emptyMessage: PropTypes.string.isRequired,
+  changeHandler: PropTypes.func.isRequired,
+  submitHandler: PropTypes.func.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+  openHandler: PropTypes.func.isRequired,
+};
+
+TextField.defaultProps = {
+  editMode: 'static',
+  saveState: null,
+  value: null,
+  visibility: 'private',
+  error: null,
+};
+
+export default connect(
+  editableFormSelector,
+  {},
+)(TextField);

--- a/src/profile/forms/elements/TextField.jsx
+++ b/src/profile/forms/elements/TextField.jsx
@@ -49,7 +49,7 @@ const TextField = ({
       cases={{
         editing: (
           <div role="dialog" aria-labelledby={`${formId}-label`}>
-            <form onSubmit={handleSubmit}>
+            <form data-testid="test-form" onSubmit={handleSubmit}>
               <Form.Group
                 controlId={formId}
                 isInvalid={error !== null}
@@ -142,3 +142,5 @@ TextField.defaultProps = {
 };
 
 export default connect(editableFormSelector, {})(TextField);
+
+export const TestableTextField = TextField;

--- a/src/profile/forms/elements/TextField.jsx
+++ b/src/profile/forms/elements/TextField.jsx
@@ -104,7 +104,7 @@ const TextField = ({
             </small>
           </>
         ),
-        static: (
+        static: value && (
           <>
             <EditableItemHeader content={label} />
             <p data-hj-suppress className="h5">{value}</p>

--- a/src/profile/forms/elements/TextField.jsx
+++ b/src/profile/forms/elements/TextField.jsx
@@ -30,20 +30,20 @@ const TextField = ({
 
   useEffect(() => {
     if (!value && errorMessage?.required) {
-      setErrorMessage(errorMessage.required);
-    } else if (restrictions.max_length && value.length > restrictions.max_length) {
-      setErrorMessage(errorMessage.max_length);
-    } else if (restrictions.min_length && value.length < restrictions.min_length) {
-      setErrorMessage(errorMessage.min_length);
+      setErrorMessage(errorMessage?.required);
+    } else if (restrictions?.max_length && value?.length > restrictions?.max_length) {
+      setErrorMessage(errorMessage?.max_length);
+    } else if (restrictions?.min_length && value?.length < restrictions?.min_length) {
+      setErrorMessage(errorMessage?.min_length);
     } else {
       setErrorMessage(null);
     }
   }, [
-    errorMessage.max_length,
-    errorMessage.min_length,
-    errorMessage.required,
-    restrictions.max_length,
-    restrictions.min_length,
+    errorMessage?.max_length,
+    errorMessage?.min_length,
+    errorMessage?.required,
+    restrictions?.max_length,
+    restrictions?.min_length,
     value,
   ]);
 
@@ -85,8 +85,8 @@ const TextField = ({
                   name={formId}
                   value={value}
                   onChange={handleChange}
-                  minLength={restrictions.min_length}
-                  maxLength={restrictions.max_length}
+                  minLength={restrictions?.min_length}
+                  maxLength={restrictions?.max_length}
                 />
                 {displayedMessage !== null && (
                 <Form.Control.Feedback hasIcon={false}>

--- a/src/profile/forms/elements/TextField.test.jsx
+++ b/src/profile/forms/elements/TextField.test.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { TestableTextField } from './TextField';
+
+const mockStore = configureStore([]);
+
+describe('TextField', () => {
+  const defaultProps = {
+    formId: 'test-text',
+    value: '',
+    visibility: 'private',
+    editMode: 'editing',
+    saveState: null,
+    error: null,
+    label: 'Username',
+    placeholder: 'Enter your username',
+    instructions: 'Provide a unique username',
+    changeHandler: jest.fn(),
+    submitHandler: jest.fn(),
+    closeHandler: jest.fn(),
+    openHandler: jest.fn(),
+  };
+
+  let store;
+
+  beforeEach(() => {
+    store = mockStore({});
+  });
+
+  const renderComponent = (props = {}) => {
+    render(
+      <Provider store={store}>
+        <IntlProvider locale="en">
+          <TestableTextField {...defaultProps} {...props} />
+        </IntlProvider>
+      </Provider>,
+    );
+  };
+
+  it('renders text field in editing mode', () => {
+    renderComponent();
+    expect(screen.getByLabelText('Username')).toBeInTheDocument();
+  });
+
+  it('calls changeHandler when text is entered', () => {
+    renderComponent();
+    const input = screen.getByLabelText('Username');
+    fireEvent.change(input, { target: { value: 'new-user' } });
+    expect(defaultProps.changeHandler).toHaveBeenCalledWith('test-text', 'new-user');
+  });
+
+  it('calls submitHandler when form is submitted', () => {
+    renderComponent();
+    const form = screen.getByTestId('test-form');
+    fireEvent.submit(form);
+    expect(defaultProps.submitHandler).toHaveBeenCalledWith('test-text');
+  });
+
+  it('calls closeHandler when form is closed', () => {
+    renderComponent();
+    defaultProps.closeHandler.mockClear();
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(defaultProps.closeHandler).toHaveBeenCalledWith('test-text');
+  });
+
+  it('renders empty state when in empty mode', () => {
+    renderComponent({ editMode: 'empty' });
+    expect(screen.getByText('Provide a unique username')).toBeInTheDocument();
+    expect(screen.getByText('Enter your username')).toBeInTheDocument();
+  });
+
+  it('renders static mode with entered value', () => {
+    renderComponent({ editMode: 'static', value: 'existing-user' });
+    expect(screen.getByText('existing-user')).toBeInTheDocument();
+  });
+
+  it('renders editable mode with edit button', () => {
+    renderComponent({ editMode: 'editable' });
+    expect(screen.getByText('Username')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it('calls openHandler when edit button is clicked', () => {
+    renderComponent({ editMode: 'editable' });
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    expect(defaultProps.openHandler).toHaveBeenCalledWith('test-text');
+  });
+});

--- a/src/profile/forms/elements/TextField.test.jsx
+++ b/src/profile/forms/elements/TextField.test.jsx
@@ -14,7 +14,15 @@ describe('TextField', () => {
     visibility: 'private',
     editMode: 'editing',
     saveState: null,
-    error: null,
+    errorMessage: {
+      required: 'This field is required',
+      max_length: 'This field is too long',
+      min_length: 'This field is too short',
+    },
+    restrictions: {
+      max_length: 50,
+      min_length: 5,
+    },
     label: 'Username',
     placeholder: 'Enter your username',
     instructions: 'Provide a unique username',

--- a/src/profile/utils.js
+++ b/src/profile/utils.js
@@ -23,6 +23,10 @@ export function modifyObjectKeys(object, modify) {
   return result;
 }
 
+export function capitalizeFirstLetter(val) {
+  return String(val).charAt(0).toUpperCase() + String(val).slice(1);
+}
+
 export function camelCaseObject(object) {
   return modifyObjectKeys(object, camelCase);
 }

--- a/src/profile/utils.js
+++ b/src/profile/utils.js
@@ -73,3 +73,20 @@ export class AsyncActionType {
     return `${this.topic}__${this.name}__RESET`;
   }
 }
+
+/**
+ * Sort fields so that checkbox fields are at the end of the list.
+ * @param {object} a the first field to compare
+ * @param {object} b the second field to compare
+ * @returns a negative integer if a should come before b, a positive integer
+ * if a should come after b, or 0 if a and b have the same order
+ */
+export const moveCheckboxFieldsToEnd = (a, b) => {
+  if (a.type === 'checkbox' && b.type !== 'checkbox') {
+    return 1;
+  }
+  if (a.type !== 'checkbox' && b.type === 'checkbox') {
+    return -1;
+  }
+  return 0;
+};

--- a/src/profile/utils.test.js
+++ b/src/profile/utils.test.js
@@ -4,6 +4,8 @@ import {
   camelCaseObject,
   snakeCaseObject,
   convertKeyNames,
+  moveCheckboxFieldsToEnd,
+  capitalizeFirstLetter,
 } from './utils';
 
 describe('modifyObjectKeys', () => {
@@ -99,5 +101,69 @@ describe('AsyncActionType', () => {
     expect(actionType.SUCCESS).toBe('HOUSE_CATS__START_THE_RACE__SUCCESS');
     expect(actionType.FAILURE).toBe('HOUSE_CATS__START_THE_RACE__FAILURE');
     expect(actionType.RESET).toBe('HOUSE_CATS__START_THE_RACE__RESET');
+  });
+
+  describe('moveCheckboxFieldsToEnd', () => {
+    it('returns 1 when first field is checkbox and second field is not', () => {
+      const a = { type: 'checkbox' };
+      const b = { type: 'text' };
+
+      expect(moveCheckboxFieldsToEnd(a, b)).toEqual(1);
+    });
+
+    it('returns -1 when first field is not checkbox and second field is', () => {
+      const a = { type: 'text' };
+      const b = { type: 'checkbox' };
+
+      expect(moveCheckboxFieldsToEnd(a, b)).toEqual(-1);
+    });
+
+    it('returns 0 when both fields are checkboxes', () => {
+      const a = { type: 'checkbox' };
+      const b = { type: 'checkbox' };
+
+      expect(moveCheckboxFieldsToEnd(a, b)).toEqual(0);
+    });
+
+    it('returns 0 when neither field is a checkbox', () => {
+      const a = { type: 'text' };
+      const b = { type: 'text' };
+
+      expect(moveCheckboxFieldsToEnd(a, b)).toEqual(0);
+    });
+  });
+
+  describe('capitalizeFirstLetter', () => {
+    it('capitalizes the first letter of a string', () => {
+      expect(capitalizeFirstLetter('hello')).toBe('Hello');
+    });
+
+    it('returns an empty string when given an empty string', () => {
+      expect(capitalizeFirstLetter('')).toBe('');
+    });
+
+    it('handles single character strings', () => {
+      expect(capitalizeFirstLetter('a')).toBe('A');
+    });
+
+    it('handles strings with only one word', () => {
+      expect(capitalizeFirstLetter('word')).toBe('Word');
+    });
+
+    it('handles strings with multiple words', () => {
+      expect(capitalizeFirstLetter('multiple words')).toBe('Multiple words');
+    });
+
+    it('handles non-string inputs by converting them to strings', () => {
+      expect(capitalizeFirstLetter(123)).toBe('123');
+      expect(capitalizeFirstLetter(null)).toBe('Null');
+      expect(capitalizeFirstLetter(undefined)).toBe('Undefined');
+      expect(capitalizeFirstLetter(true)).toBe('True');
+    });
+
+    it('handles strings with special characters', () => {
+      expect(capitalizeFirstLetter('!hello')).toBe('!hello');
+      expect(capitalizeFirstLetter('@world')).toBe('@world');
+    });
   });
 });


### PR DESCRIPTION
### Description

This PR aims to allow the extension of the default profile fields by using the `extended_profile_fields` feature with a custom form app like [the example](https://github.com/open-craft/custom-form-app) 

#### Main changes

- [src/profile/forms/ExtendedProfileFields.jsx](https://github.com/openedx/frontend-app-profile/pull/1167/files#diff-8b393b2acaae7418d99da40c011d7aac3fa68f2748933ab2fad1bf6fbd5e3912): New component to manage the fields added to the `extended_profile_field` settings attribute (it is only covered checkbox, text and select fields)
- [src/profile/data/services.js](https://github.com/openedx/frontend-app-profile/pull/1167/files#diff-24d36b0612b57228e9a82b065fca63d7e0e043515046d0d1ad205998d1f89c58R159): Add a service to retrieve all the extended profile field properties (these are added with the custom form app and retrieved to the MFE with the `mfe_context` API)
- [src/profile/data/selectors.js](https://github.com/openedx/frontend-app-profile/pull/1167/files#diff-e4660ea560e90d27c994621005d359290771ee14441086ee4d6682d497fca8d4R409-R417): Add the `fieldValue`s from the `extended_profile` account prop to the `extended_profile_fields` attributes since the data is fetched

#### How Has This Been Tested?
1. Init a `Sumac` environment
2. Git clone and mount this MFE with `tutor mounts add /path/to/cloned/mfe`
3. Git clone [this custom form app](https://github.com/bra-i-am/custom-form-app) which counts with checkbox, select and text fields
4. Mount the custom form app with `tutor mounts add lms:/path/to/cloned/custom-form-app:/openedx/extra-deps/custom-form-app` and install it using `tutor dev exec lms pip install -e ../extra-deps/custom-form-app`
5. Add the following env variables
    ``` YML
    # lms.env.yml
    ADDL_INSTALLED_APPS:
      - "custom_reg_form"
    ENABLE_COMBINED_LOGIN_REGISTRATION: true
    REGISTRATION_EXTENSION_FORM: "custom_reg_form.forms.ExtraInfoForm"

    # cms.env.yml
    ENABLE_COMBINED_LOGIN_REGISTRATION: true
    ```
6. Add the following settings to the `Site Configurations > local.openedx.io:8000`:
    ``` JSON
    {
        "ENABLE_PROFILE_MICROFRONTEND": "true",
        "ENABLE_DYNAMIC_REGISTRATION_FIELDS": "true",
        "MFE_CONFIG": {
            "ENABLE_DYNAMIC_REGISTRATION_FIELDS": "true"
        },
        "REGISTRATION_EXTRA_FIELDS": {
            "employment_situation": "required",
            "data_authorization": "required",
            "allow_newsletter": "required",
            "terms_of_service": "hidden",
            "honor_code": "hidden",
            "full_name": "required",
            "bio": "required",
            "wants_newsletter": "required",
            "favorite_language": "required",
            "password_hint": "required",
            "terms_accepted": "required"
        },
        "extended_profile_fields": [
            "data_authorization",
            "full_name",
            "bio",
            "wants_newsletter",
            "favorite_language",
            "password_hint",
            "terms_accepted"
        ]
    }
    ```
8. Run `tutor dev restart`
9. When you go to your profile (Profile MFE), you'll interact with the extended fields added [through the custom form app](https://github.com/bra-i-am/custom-form-app/blob/master/custom_reg_form/forms.py#L26)

#### Screenshots/sandbox (optional):

![image](https://github.com/user-attachments/assets/89b99711-283f-4eab-8135-9d074eb0a434)
![image](https://github.com/user-attachments/assets/f0246c7f-5ccb-4c87-903f-9077749c9270)
