### PR TITLE
feat: Resize textarea using alt+up and alt+down arrow keys

### DIFF
--- a/src/profile/forms/Bio.jsx
+++ b/src/profile/forms/Bio.jsx
@@ -19,10 +19,12 @@ class Bio extends React.Component {
   constructor(props) {
     super(props);
 
+    this.textareaRef = React.createRef();
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleClose = this.handleClose.bind(this);
     this.handleOpen = this.handleOpen.bind(this);
+    this.handleResize = this.handleResize.bind(this);
   }
 
   handleChange(e) {
@@ -41,6 +43,25 @@ class Bio extends React.Component {
 
   handleOpen() {
     this.props.openHandler(this.props.formId);
+  }
+
+  handleResize(event) {
+    if (event.altKey) {
+      const textarea = this.textareaRef.current;
+      if (!textarea) {
+        return;
+      }
+
+      const step = 10; // pixels to increase/decrease the height of the textarea
+      if (event.key === 'ArrowUp') {
+        textarea.style.height = `${Math.max(30, textarea.offsetHeight - step)}px`;
+        event.preventDefault();
+      }
+      if (event.key === 'ArrowDown') {
+        textarea.style.height = `${textarea.offsetHeight + step}px`;
+        event.preventDefault();
+      }
+    }
   }
 
   render() {
@@ -68,7 +89,9 @@ class Bio extends React.Component {
                     id={formId}
                     name={formId}
                     value={bio}
+                    ref={this.textareaRef}
                     onChange={this.handleChange}
+                    onKeyDown={this.handleResize}
                   />
                   {error !== null && (
                     <Form.Control.Feedback hasIcon={false}>


### PR DESCRIPTION
### 📝 Description

This PR introduces a keyboard accessibility enhancement to the textarea component, allowing users to resize it vertically using the keyboard. Specifically:

- Pressing **Alt + ↑ (Up Arrow)** decreases the height of the textarea.
- Pressing **Alt + ↓ (Down Arrow)** increases the height of the textarea.

This improvement supports keyboard-only users and enhances overall usability.

**Related issue:** [tutor-indigo/#146](https://github.com/overhangio/tutor-indigo/issues/146)  
**Taiga Task (if accessible):** [US 75 – Keyboard accessible textarea resizing](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/75)
**Live Preview:** [Profile Page – Sandbox](https://apps.sandbox.openedx.edly.io/profile/u/admin)

---

### 🧪 How Has This Been Tested?

- Manually tested across Chrome, Firefox, and Safari.
- Verified that the height increases/decreases correctly with the specified key combinations.
- Confirmed that default textarea behavior and form submission remain intact.

---

### 🖼️ Screenshots/Sandbox (optional):
![image](https://github.com/user-attachments/assets/94878f30-4cf3-4d87-aa67-144270b16ced)

| Before | After |
|--------|-------|
| Textarea not resizable via keyboard | Textarea resizable using Alt + ↑ / ↓ |

---

### ✅ Merge Checklist

- [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.  
- [x] Is there adequate test coverage for your changes?

---

### 📦 Post-merge Checklist

- [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/2u-infinity** to do it.  
- [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
