### PR TITLE
feat: made fullname uneditable and added redirect link

### DIFF
--- a/src/pacts/frontend-app-profile-edx-platform.json
+++ b/src/pacts/frontend-app-profile-edx-platform.json
@@ -36,11 +36,7 @@
           "dateJoined": "2017-06-07T00:44:23Z",
           "email": "staff@example.com",
           "isActive": true,
-          "languageProficiencies": [],
-          "levelOfEducation": null,
           "name": "Lemon Seltzer",
-          "profileImage": {},
-          "socialLinks": [],
           "username": "staff",
           "yearOfBirth": 1901
         },

--- a/src/profile-v2/ProfilePage.jsx
+++ b/src/profile-v2/ProfilePage.jsx
@@ -79,8 +79,7 @@ const ProfilePage = ({ params }) => {
   const isTabletView = useIsOnTabletScreen();
 
   useEffect(() => {
-    const { CREDENTIALS_BASE_URL } = context.config;
-    const { ACCOUNT_SETTINGS_URL } = context.config;
+    const { ACCOUNT_SETTINGS_URL, CREDENTIALS_BASE_URL } = context.config;
     if (CREDENTIALS_BASE_URL) {
       setViewMyRecordsUrl(`${CREDENTIALS_BASE_URL}/records`);
     }

--- a/src/profile-v2/ProfilePage.jsx
+++ b/src/profile-v2/ProfilePage.jsx
@@ -42,7 +42,7 @@ import messages from './ProfilePage.messages';
 import withParams from '../utils/hoc';
 import { useIsOnMobileScreen, useIsOnTabletScreen } from './data/hooks';
 
-ensureConfig(['CREDENTIALS_BASE_URL', 'LMS_BASE_URL'], 'ProfilePage');
+ensureConfig(['CREDENTIALS_BASE_URL', 'LMS_BASE_URL', 'ACCOUNT_SETTINGS_URL'], 'ProfilePage');
 
 const ProfilePage = ({ params }) => {
   const dispatch = useDispatch();
@@ -74,17 +74,13 @@ const ProfilePage = ({ params }) => {
 
   const navigate = useNavigate();
   const [viewMyRecordsUrl, setViewMyRecordsUrl] = useState(null);
-  const [viewAccountSettingsUrl, setViewAccountSettingsUrl] = useState(null);
   const isMobileView = useIsOnMobileScreen();
   const isTabletView = useIsOnTabletScreen();
 
   useEffect(() => {
-    const { ACCOUNT_SETTINGS_URL, CREDENTIALS_BASE_URL } = context.config;
+    const { CREDENTIALS_BASE_URL } = context.config;
     if (CREDENTIALS_BASE_URL) {
       setViewMyRecordsUrl(`${CREDENTIALS_BASE_URL}/records`);
-    }
-    if (ACCOUNT_SETTINGS_URL) {
-      setViewAccountSettingsUrl(ACCOUNT_SETTINGS_URL);
     }
 
     dispatch(fetchProfile(params.username));
@@ -321,7 +317,7 @@ const ProfilePage = ({ params }) => {
                   {isBlockVisible(name) && (
                   <Name
                     name={name}
-                    accountSettingsUrl={viewAccountSettingsUrl}
+                    accountSettingsUrl={context.config.ACCOUNT_SETTINGS_URL}
                     visibilityName={visibilityName}
                     formId="name"
                     {...commonFormProps}

--- a/src/profile-v2/ProfilePage.jsx
+++ b/src/profile-v2/ProfilePage.jsx
@@ -74,13 +74,18 @@ const ProfilePage = ({ params }) => {
 
   const navigate = useNavigate();
   const [viewMyRecordsUrl, setViewMyRecordsUrl] = useState(null);
+  const [viewAccountSettingsUrl, setViewAccountSettingsUrl] = useState(null);
   const isMobileView = useIsOnMobileScreen();
   const isTabletView = useIsOnTabletScreen();
 
   useEffect(() => {
     const { CREDENTIALS_BASE_URL } = context.config;
+    const { ACCOUNT_SETTINGS_URL } = context.config;
     if (CREDENTIALS_BASE_URL) {
       setViewMyRecordsUrl(`${CREDENTIALS_BASE_URL}/records`);
+    }
+    if (ACCOUNT_SETTINGS_URL) {
+      setViewAccountSettingsUrl(ACCOUNT_SETTINGS_URL);
     }
 
     dispatch(fetchProfile(params.username));
@@ -317,6 +322,7 @@ const ProfilePage = ({ params }) => {
                   {isBlockVisible(name) && (
                   <Name
                     name={name}
+                    accountSettingsUrl={viewAccountSettingsUrl}
                     visibilityName={visibilityName}
                     formId="name"
                     {...commonFormProps}

--- a/src/profile-v2/forms/Name.jsx
+++ b/src/profile-v2/forms/Name.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { InfoOutline } from '@openedx/paragon/icons';
-import { Form, OverlayTrigger, Tooltip } from '@openedx/paragon';
+import { Hyperlink, OverlayTrigger, Tooltip } from '@openedx/paragon';
 import messages from './Name.messages';
 
 import FormControls from './elements/FormControls';
@@ -26,11 +26,11 @@ const Name = ({
   visibilityName,
   editMode,
   saveState,
-  error,
   changeHandler,
   submitHandler,
   closeHandler,
   openHandler,
+  accountSettingsUrl,
 }) => {
   const isVisibilityEnabled = useIsVisibilityEnabled();
   const intl = useIntl();
@@ -62,23 +62,17 @@ const Name = ({
                           {intl.formatMessage(messages['profile.name.tooltip'])}
                         </p>
                       </Tooltip>
-                          )}
+                            )}
                   >
                     <InfoOutline className="m-0 info-icon" />
                   </OverlayTrigger>
                 </div>
-                <textarea
-                  className="form-control py-10px"
-                  id={formId}
-                  name={formId}
-                  value={name}
-                  onChange={handleChange}
-                />
-                {error !== null && (
-                <Form.Control.Feedback hasIcon={false}>
-                  {error}
-                </Form.Control.Feedback>
-                )}
+                <EditableItemHeader content={name} />
+                <h4 className="font-weight-normal">
+                  <Hyperlink destination={accountSettingsUrl} target="_blank">
+                    {intl.formatMessage(messages['profile.name.redirect'])}
+                  </Hyperlink>
+                </h4>
               </div>
               <FormControls
                 visibilityId="visibilityName"
@@ -182,7 +176,7 @@ Name.propTypes = {
   submitHandler: PropTypes.func.isRequired,
   closeHandler: PropTypes.func.isRequired,
   openHandler: PropTypes.func.isRequired,
-  error: PropTypes.string,
+  accountSettingsUrl: PropTypes.string.isRequired,
 };
 
 Name.defaultProps = {
@@ -190,7 +184,6 @@ Name.defaultProps = {
   saveState: null,
   name: null,
   visibilityName: 'private',
-  error: null,
 };
 
 export default connect(

--- a/src/profile-v2/forms/Name.messages.jsx
+++ b/src/profile-v2/forms/Name.messages.jsx
@@ -16,6 +16,11 @@ const messages = defineMessages({
     defaultMessage: 'The name that is used for ID verification and that appears on your certificates',
     description: 'Tooltip for the full name field.',
   },
+  'profile.name.redirect': {
+    id: 'profile.name.redirect',
+    defaultMessage: 'Edit full name from the Accounts page',
+    description: 'Redirect message for editing the name from the Accounts page.',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
Ticket: [INF-1890](https://2u-internal.atlassian.net/browse/INF-1890)

We added edit functionality for the full name field while making the Profile editable. While testing on stage, we observed that some users require ID Verification to change their full name. The flow for ID verification only exists in Accounts MFE. 

Hence, we are removing the edit functionality of the full name field and providing a redirect link to edit it on the Accounts page instead.  