### PR TITLE
test: Add Node 24 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,13 @@ jobs:
         - i18n_extract
         - lint
         - test
+        node: [20, 24]
+    continue-on-error: ${{ matrix.node == 24 }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version-file: '.nvmrc'
+        node-version: ${{ matrix.node }}
     - run: make requirements
     - run: make test NPM_TESTS=build
     - run: make test NPM_TESTS=${{ matrix.npm-test }}


### PR DESCRIPTION
### Description
As a first step in the upgrade to Node 24, add it to the CI matrix as a non-blocking test.
See [the tracking issue](https://github.com/openedx/frontend-app-profile/issues/1219) for further information.