### PR TITLE
test: Remove support for Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,11 @@ jobs:
         - i18n_extract
         - lint
         - test
-        node: [20, 24]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node }}
+        node-version-file: '.nvmrc'
     - run: make requirements
     - run: make test NPM_TESTS=build
     - run: make test NPM_TESTS=${{ matrix.npm-test }}


### PR DESCRIPTION
> [!NOTE]
> Awaiting a merge:
> 
> * [test: Add Node 24 to CI matrix](https://github.com/openedx/frontend-app-profile/pull/1262)
> * [build: Upgrade to Node 24](https://github.com/openedx/frontend-app-profile/pull/1266)

Description
Complete the upgrade to Node 24 by removing the Node 20 CI check and going back to using .nvmrc as the source of truth for which version to use.

See https://github.com/openedx/frontend-app-profile/issues/1219 for futher information.