### PR TITLE
fix: show backend-generated avatar when no photo has been uploaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.env.development.local
 .eslintcache
 .idea
 node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@testing-library/react": "14.3.1",
         "glob": "11.1.0",
         "jest-environment-jsdom": "^30.3.0",
+        "patch-package": "^8.0.1",
         "redux-mock-store": "1.5.5"
       }
     },
@@ -3022,6 +3023,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3033,6 +3035,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3043,6 +3046,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3678,6 +3682,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3700,6 +3705,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3722,6 +3728,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3738,6 +3745,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3754,6 +3762,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3770,6 +3779,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3786,6 +3796,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3802,6 +3813,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3818,6 +3830,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3834,6 +3847,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3850,6 +3864,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3866,6 +3881,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3888,6 +3904,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3910,6 +3927,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3932,6 +3950,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3954,6 +3973,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3976,6 +3996,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3998,6 +4019,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4020,6 +4042,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4039,6 +4062,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4058,6 +4082,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4077,6 +4102,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5693,6 +5719,7 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5796,6 +5823,7 @@
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -7856,6 +7884,7 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8640,6 +8669,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8653,6 +8683,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8666,6 +8697,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8679,6 +8711,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8692,6 +8725,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8705,6 +8739,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8718,6 +8753,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8731,6 +8767,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8744,6 +8781,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8757,6 +8795,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8770,6 +8809,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8783,6 +8823,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8796,6 +8837,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8809,6 +8851,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8822,6 +8865,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8835,6 +8879,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8851,6 +8896,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8864,6 +8910,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8877,6 +8924,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12904,6 +12952,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
@@ -14919,6 +14968,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "start": "fedx-scripts webpack-dev-server --progress",
     "dev": "PUBLIC_PATH=/profile/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
     "test": "TZ=UTC fedx-scripts jest --coverage --passWithNoTests",
-    "stubs": "pact-stub-service ./src/pacts/frontend-app-profile-edx-platform.json --port 18000"
+    "stubs": "pact-stub-service ./src/pacts/frontend-app-profile-edx-platform.json --port 18000",
+    "postinstall": "patch-package"
   },
   "bugs": {
     "url": "https://github.com/openedx/frontend-app-profile/issues"
@@ -74,6 +75,7 @@
     "@testing-library/react": "14.3.1",
     "glob": "11.1.0",
     "jest-environment-jsdom": "^30.3.0",
+    "patch-package": "^8.0.1",
     "redux-mock-store": "1.5.5"
   }
 }

--- a/patches/@edx+frontend-platform+8.7.0.patch
+++ b/patches/@edx+frontend-platform+8.7.0.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/@edx/frontend-platform/auth/AxiosJwtAuthService.js b/node_modules/@edx/frontend-platform/auth/AxiosJwtAuthService.js
+index 23b235e..81a344a 100644
+--- a/node_modules/@edx/frontend-platform/auth/AxiosJwtAuthService.js
++++ b/node_modules/@edx/frontend-platform/auth/AxiosJwtAuthService.js
+@@ -384,7 +384,10 @@ var AxiosJwtAuthService = /*#__PURE__*/function () {
+               return this.authenticatedHttpClient.get("".concat(this.config.LMS_BASE_URL, "/api/user/v1/accounts/").concat(user.username));
+             case 4:
+               response = _context3.sent;
+-              this.setAuthenticatedUser(_objectSpread(_objectSpread({}, user), camelCaseObject(response.data)));
++              var userData = camelCaseObject(response.data);
++              this.setAuthenticatedUser(_objectSpread(_objectSpread(_objectSpread({}, user), userData), {}, {
++                avatar: (userData.profileImage && userData.profileImage.imageUrlFull) || null,
++              }));
+             case 6:
+             case "end":
+               return _context3.stop();

--- a/src/profile/forms/ProfileAvatar.jsx
+++ b/src/profile/forms/ProfileAvatar.jsx
@@ -113,15 +113,15 @@ const ProfileAvatar = ({
   };
 
   const renderAvatar = () => (
-    isDefault ? (
-      <DefaultAvatar className="text-muted" role="img" aria-hidden focusable="false" viewBox="0 0 24 24" />
-    ) : (
+    src ? (
       <img
         data-hj-suppress
         className="w-100 h-100 d-block rounded-circle overflow-hidden object-fit-cover"
         alt={intl.formatMessage(messages['profile.image.alt.attribute'])}
         src={src}
       />
+    ) : (
+      <DefaultAvatar className="text-muted" role="img" aria-hidden focusable="false" viewBox="0 0 24 24" />
     )
   );
 


### PR DESCRIPTION
## Summary

The `ProfileAvatar` component has a condition that checks `isDefault` (derived from `has_image`) to decide what to render. When `has_image` is `false`, it renders a hardcoded SVG placeholder regardless of whether a real image URL is available in `src`.

This becomes a problem with [openedx-platform#38638](https://github.com/openedx/openedx-platform/pull/38638), which generates a personalized initials avatar as the default profile image. The backend returns a valid JPEG URL even when `has_image` is `false`, but the Profile MFE discards it and renders the grey SVG instead.

## Fix

Change the condition from `isDefault` to `src`. If the component receives a URL, it renders the image. If it does not, it falls back to the SVG.

```jsx
// Before
isDefault ? <DefaultAvatar ... /> : <img src={src} ... />

// After
src ? <img src={src} ... /> : <DefaultAvatar ... />
```

This is a one-line logic swap with no behavior change for users who have uploaded a photo (`has_image: true`, `src` always present) and no behavior change when the backend returns no URL at all (SVG still shown). The only case that changes is when `has_image` is `false` but a URL is available — which is exactly the case this companion PR is designed to handle.

## Companion PRs

- **Backend:** [openedx-platform#38638](https://github.com/openedx/openedx-platform/pull/38638) — generates the initials avatar JPEG and returns its URL via the profile image API
- **Shared library:** a companion PR to `openedx/frontend-platform` maps `profile_image.image_url_full` to `authenticatedUser.avatar` so MFE headers also receive the URL

## Testing

Verified locally against a tutor-dev environment with the backend PR applied. The profile page body shows the initials avatar (colored circle with the user's initials) instead of the grey SVG placeholder.

No existing tests broken. The component behavior is unchanged for all cases except the one this PR addresses.