### PR TITLE
fix: show full country list when LMS sends no country allow-list

### DIFF
--- a/src/profile/data/selectors.js
+++ b/src/profile/data/selectors.js
@@ -98,6 +98,10 @@ export const sortedCountriesSelector = createSelector(
     const countryList = getCountryList(locale);
     const userCountry = profileAccount.country;
 
+    if (countriesCodesList.length === 0) {
+      return countryList;
+    }
+
     return countryList.filter(({ code }) => code === userCountry || countriesCodesList.find(x => x === code));
   },
 );

--- a/src/profile/data/selectors.test.js
+++ b/src/profile/data/selectors.test.js
@@ -1,0 +1,47 @@
+import { getCountryList, getLocale } from '@edx/frontend-platform/i18n';
+import { sortedCountriesSelector } from './selectors';
+
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  ...jest.requireActual('@edx/frontend-platform/i18n'),
+  getLocale: jest.fn(),
+  getCountryList: jest.fn(),
+}));
+
+const countries = [
+  { code: 'CA', name: 'Canada' },
+  { code: 'UA', name: 'Ukraine' },
+  { code: 'GB', name: 'United Kingdom' },
+  { code: 'US', name: 'United States' },
+];
+
+const buildState = ({ countriesCodesList, country = null }) => ({
+  profilePage: {
+    account: { country },
+    countriesCodesList,
+  },
+});
+
+describe('sortedCountriesSelector', () => {
+  beforeEach(() => {
+    getLocale.mockReturnValue('en');
+    getCountryList.mockReturnValue(countries);
+  });
+
+  it('returns the full country list when the LMS sends no allow-list', () => {
+    const result = sortedCountriesSelector(buildState({ countriesCodesList: [] }));
+
+    expect(result).toEqual(countries);
+  });
+
+  it('keeps only allow-listed countries when the LMS sends a list', () => {
+    const result = sortedCountriesSelector(buildState({ countriesCodesList: ['US', 'CA'] }));
+
+    expect(result.map(({ code }) => code)).toEqual(['CA', 'US']);
+  });
+
+  it('always keeps the country already saved on the account', () => {
+    const result = sortedCountriesSelector(buildState({ countriesCodesList: ['US'], country: 'UA' }));
+
+    expect(result.map(({ code }) => code)).toEqual(['UA', 'US']);
+  });
+});


### PR DESCRIPTION
### Description

On the learner profile page the **Country** selector renders with a single empty placeholder option - no countries can be selected.

This happens on any deployment that keeps the platform default `REGISTRATION_EXTRA_FIELDS['country'] = 'hidden'` (`edx-platform: openedx/envs/common.py:1679`).

**Steps to reproduce**

1. Leave `REGISTRATION_EXTRA_FIELDS['country']` at its default `'hidden'` (no Site Configuration override).
2. Log in and open `/profile/u/<username>`.
3. Click **Add country** (or the edit icon on the Country block).

**Expected:** the localized list of countries, as on the Account Settings page.
**Actual:** the `<select id="country">` contains only the empty placeholder — 1 option, 0 countries.

| Account | Profile |
|--------|--------|
| <img width="100%" height="auto" alt="Screenshot 2026-09-10 at 11 03 43" src="https://github.com/user-attachments/assets/fe9c8a01-b74a-4db7-8078-fa7f38db3786" /> | <img width="100%" height="auto" alt="Screenshot 2026-09-10 at 11 18 46" src="https://github.com/user-attachments/assets/3e05b6fc-c514-4b8d-8764-555b7c14df25" /> | 


**Root cause**

The profile builds its list of selectable countries from the **registration form description**, not from a country/locale source:

| Step | Location | What happens |
|---|---|---|
| 1 | `src/profile/data/sagas.js:43-63` | fetched alongside account/certificates/preferences on profile load |
| 2 | `src/profile/data/services.js:158` | `getCountryList()` → `GET {LMS_BASE_URL}/user_api/v1/account/registration/` |
| 3 | `src/profile/data/services.js:152` | `extractCountryList()` takes `fields[name == 'country'].options`, maps them to codes; returns `[]` on any miss |
| 4 | `src/profile/data/actions.js:21` → `src/profile/data/reducers.js:66` | stored in `state.profilePage.countriesCodesList` |
| 5 | `src/profile/data/selectors.js:93-103` | `sortedCountriesSelector` filters the full localized list by those codes |

The registration endpoint only includes a `country` field when the registration form is configured to show it. With the default `'hidden'`, `countriesCodesList` arrives as `[]` and the filter is still applied unconditionally:

```js
return countryList.filter(({ code }) => code === userCountry
  || countriesCodesList.find(x => x === code));
```

Every entry is removed. Only the learner's already-committed country survives, so an account with no country set is left with nothing to choose from.

`[]` also arrives when the request fails (`services.js:164` logs and returns `[]`), so a transient error produces the same dead dropdown.

**Regression**

Introduced by #1185 (29edfa9, *feat: added restricted country functionality*), which replaced

```js
sortedCountriesSelector = createSelector(localeSelector,
  locale => getCountryList(locale));
```

with the allow-list filter. The intent was to hide embargoed countries, but the registration form was used as a proxy for "not embargoed" — which only holds on sites where country is part of signup.

<details>
<summary>Why Account Settings is not affected</summary>

`frontend-app-account` uses the same endpoint and the same `extractCountryList()` (`src/account-settings/data/service.js:191-202`), so its `countriesCodesList` is empty too. It renders correctly because it guards the empty case ([`AccountSettingsPage.jsx#L167-L175`](https://github.com/openedx/frontend-app-account/blob/master/src/account-settings/AccountSettingsPage.jsx#L167-L175)):

```js
removeDisabledCountries = (countryList) => {
  const { countriesCodesList, committedValues } = this.props;
  const committedCountry = committedValues?.country;

  if (!countriesCodesList.length) {
    return countryList;
  }
  return countryList.filter(({ value }) => value === committedCountry || countriesCodesList.find(x => x === value));
};
```

The per-option guard is present in both MFEs (`length > 0`); only the list-level guard is missing in profile.

</details>

**Fix**

Port the account MFE's guard into `sortedCountriesSelector` — treat an empty list as "the LMS does not restrict the choice":

```diff
  // src/profile/data/selectors.js
+ if (countriesCodesList.length === 0) {
+   return countryList;
+ }
  return countryList.filter(({ code }) => code === userCountry
    || countriesCodesList.find(x => x === code));
```

`Country.jsx:45` `isDisabledCountry()` already short-circuits on `countriesCodesList.length > 0`, so no other change is needed. Where the LMS does send an allow-list, behaviour is unchanged.

> This does not weaken the restriction: embargoed countries are rejected server-side on write, independently of the registration form — `edx-platform: openedx/core/djangoapps/user_api/accounts/api.py:162-169` returns a `country` field error for `GlobalRestrictedCountry.is_country_restricted(...)`. The frontend filter is a UX affordance, not an access control.

**One trade-off worth stating:** on a site where embargo **is** enabled and `country` is hidden in registration, the profile will now offer an embargoed country and the learner will get the server-side field error on save. That is worse than not offering it, but strictly better than today's "no options at all", and it matches what Account Settings already does.

#### How Has This Been Tested?

- Reproduced on a Tutor dev stack (Verawood) with the stock `REGISTRATION_EXTRA_FIELDS`: the country `<select>` had 1 option. With `country` present in the registration response the same build showed 251 options, confirming the allow-list filter as the cause.
- Added `src/profile/data/selectors.test.js` with three cases for `sortedCountriesSelector`: empty `countriesCodesList` returns the full list; a non-empty list filters to exactly those codes; the country already saved on the account is kept even if it is not in the list. The first case fails on `master` without this change and passes with it.
- `npm run lint` clean, `npm run test` green on Node 24: 14 suites, 85 tests, 5 snapshots. The existing mock stores carry a non-empty `countriesCodesList`, so their snapshots are unchanged.
- Test in internal ticket

#### Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable. — N/A, no visual changes.
* [x] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@jacobo-dominguez-wgu** to do it.
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
