### PR TITLE
fix: show full country list when LMS sends no country allow-list [backport to verawood]

### DIFF
--- a/src/profile/data/selectors.js
+++ b/src/profile/data/selectors.js
@@ -98,6 +98,10 @@ export const sortedCountriesSelector = createSelector(
     const countryList = getCountryList(locale);
     const userCountry = profileAccount.country;
 
+    if (countriesCodesList.length === 0) {
+      return countryList;
+    }
+
     return countryList.filter(({ code }) => code === userCountry || countriesCodesList.find(x => x === code));
   },
 );

--- a/src/profile/data/selectors.test.js
+++ b/src/profile/data/selectors.test.js
@@ -1,0 +1,47 @@
+import { getCountryList, getLocale } from '@edx/frontend-platform/i18n';
+import { sortedCountriesSelector } from './selectors';
+
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  ...jest.requireActual('@edx/frontend-platform/i18n'),
+  getLocale: jest.fn(),
+  getCountryList: jest.fn(),
+}));
+
+const countries = [
+  { code: 'CA', name: 'Canada' },
+  { code: 'UA', name: 'Ukraine' },
+  { code: 'GB', name: 'United Kingdom' },
+  { code: 'US', name: 'United States' },
+];
+
+const buildState = ({ countriesCodesList, country = null }) => ({
+  profilePage: {
+    account: { country },
+    countriesCodesList,
+  },
+});
+
+describe('sortedCountriesSelector', () => {
+  beforeEach(() => {
+    getLocale.mockReturnValue('en');
+    getCountryList.mockReturnValue(countries);
+  });
+
+  it('returns the full country list when the LMS sends no allow-list', () => {
+    const result = sortedCountriesSelector(buildState({ countriesCodesList: [] }));
+
+    expect(result).toEqual(countries);
+  });
+
+  it('keeps only allow-listed countries when the LMS sends a list', () => {
+    const result = sortedCountriesSelector(buildState({ countriesCodesList: ['US', 'CA'] }));
+
+    expect(result.map(({ code }) => code)).toEqual(['CA', 'US']);
+  });
+
+  it('always keeps the country already saved on the account', () => {
+    const result = sortedCountriesSelector(buildState({ countriesCodesList: ['US'], country: 'UA' }));
+
+    expect(result.map(({ code }) => code)).toEqual(['UA', 'US']);
+  });
+});


### PR DESCRIPTION
#### Original PR to master: https://github.com/openedx/frontend-app-profile/pull/1401

---

## Description

Backport of #1401 to `release/verawood`. Clean `git cherry-pick -x` of the master commit; `release/verawood` carries the same `sortedCountriesSelector` code as `master`, so the diff is identical.

On the learner profile page the **Country** selector renders with a single empty placeholder option — no countries can be selected. This happens on any deployment that keeps the platform default `REGISTRATION_EXTRA_FIELDS['country'] = 'hidden'`.

The profile builds its list of selectable countries from the registration form description (`GET /user_api/v1/account/registration/`). That endpoint only includes a `country` field when the registration form is configured to show it. With the default `'hidden'`, `countriesCodesList` arrives as `[]`, `sortedCountriesSelector` still applies the allow-list filter, and every country is removed. Regression from #1185 (Verawood ships it).

The fix ports the guard that `frontend-app-account` already has in `removeDisabledCountries()`: an empty allow-list means "the LMS does not restrict the choice", so the full localized list is returned. Where the LMS does send an allow-list, behaviour is unchanged. Embargoed countries are still rejected server-side on write, so this does not weaken the restriction. Full root-cause analysis and the Account Settings comparison are in #1401.

## How Has This Been Tested?

- Same change and tests as #1401: new `src/profile/data/selectors.test.js` with three cases for `sortedCountriesSelector` (empty allow-list returns the full list; non-empty list filters to exactly those codes; the country already saved on the account is kept). The first case fails on `release/verawood` without this change.
- `npm run lint` clean, `npm run test` green on Node 24: 14 suites, 85 tests, 5 snapshots.
- Reproduced on a Tutor Verawood dev stack with the stock `REGISTRATION_EXTRA_FIELDS`: the country `<select>` had 1 option; with this change it lists all countries.

## Merge Checklist

- [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable. — N/A, no visual changes.
- [x] Is there adequate test coverage for your changes?

## Post-merge Checklist

- [ ] Deploy the changes to prod after verifying on stage or ask **@jacobo-dominguez-wgu** to do it.
- [ ] 🎉 🙌 Celebrate! Thanks for your contribution.

@openedx-release-manager please review as a Verawood backport.